### PR TITLE
Update README, DISCLAIMER, gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 certs/
+.idea/
+*.iml

--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -1,4 +1,5 @@
 ## Disclaimer of Warranty
+
 This Work is provided "as is". Any express or implied warranties, including but not limited to, the implied warranties of merchantability and fitness for a particular purpose are disclaimed. In no event shall the United States Government be liable for any direct, indirect, incidental, special, exemplary or consequential damages (including, but not limited to, procurement of substitute goods or services, loss of use, data or profits, or business interruption) however caused and on any theory of liability, whether in contract, strict liability, or tort (including negligence or otherwise) arising in any way out of the use of this Work, even if advised of the possibility of such damage.
 
 The User of this Work agrees to hold harmless and indemnify the United States Government, its agents and employees from every claim or liability (whether in tort or in contract), including attorneys' fees, court costs, and expenses, arising in direct consequence of Recipient's use of the item, including but not limited to, claims or liabilities made for injury to or death of personnel of User or third parties, damage to or destruction of property of User or third parties, infringement or other violations of intellectual property or technical data rights.
@@ -6,4 +7,5 @@ The User of this Work agrees to hold harmless and indemnify the United States Go
 Nothing in this Work is intended to constitute an endorsement, explicit or implied, by the United States Government of any particular manufacturer's product or service.
 
 ## Disclaimer of Endorsement
+
 Reference herein to any specific commercial product, process, or service by trade name, trademark, manufacturer, or otherwise, in this Work does not constitute an endorsement, recommendation, or favoring by the United States Government and shall not be used for advertising or product endorsement purposes.

--- a/README.md
+++ b/README.md
@@ -1,25 +1,35 @@
 # unfetter-discover
 
-Unfetter Discover web application and container resources.  Visit <a href="http://unfetter.io">unfetter.io</a> for more information about Unfetter projects.
+Unfetter Discover web application and container resources. Visit
+[unfetter.io](http://unfetter.io) for more information about Unfetter projects.
 
 ## System Requirements
 
-* [Docker] (https://www.docker.com/)
+* [Docker](https://www.docker.com/)
 * [Docker Compose](https://www.docker.com/products/docker-compose)
 * [Node.js](https://nodejs.org)
 
 ## The Project Setup
-The entire application, Unfetter Discover, is made up of multiple of docker containers.  Each builds upon the other.  We use  [Docker Compose](https://www.docker.com/products/docker-compose) to manage
-the startup and shutdown of all those Docker containers.  
+The entire application, Unfetter Discover, is made up of multiple of docker
+containers. Each builds upon the other. We use
+[Docker Compose](https://www.docker.com/products/docker-compose) to manage
+the startup and shutdown of all those Docker containers.
 
-The GitHub organization [unfetter-discover](https://www.github.com/unfetter-discover) houses a GitHub project for every container.  There is two ways to run Unfetter Discover.  You can run all the containers from Docker Hub, without recompiling.  
-This is recommended for most cases.
+The GitHub organization [unfetter-discover](1) houses a GitHub project for
+every container. There are two ways to run Unfetter Discover:
 
-If you are a developer, and would liked to build the Unfetter-Discover project from source, then you will need to clone all the repos in [unfetter-discover](https://www.github.com/unfetter-discover) 
-and use a different docker-compose config file.
+1. You can run all the containers from Docker Hub, without recompiling. This
+is recommended for most cases.
 
-###Build from Docker Hub.  Normal Use Case
-You will only need to clone the unfetter project.  Then, run docker-compose with default arguments.  First, go into your working directory that you want to clone the main project.
+2. If you are a developer and would like to build the Unfetter-Discover project
+from source, then you will need to clone all the repos in [unfetter-discover](1)
+and use the `docker-compose.development.yml` config file.
+
+### Case 1: Build from Docker Hub.  Normal Use Case
+
+You will only need to clone the unfetter project. Then, run docker-compose
+with default arguments. First, go into your working directory that you want
+to clone the main project.
 
 ```bash
 git clone https://github.com/unfetter-discover/unfetter.git
@@ -27,8 +37,9 @@ cd unfetter
 docker-compose up
 ```
 
-###Build from local source files.  Developer Use Case
-You will first need to clone all the projects in [unfetter-discover](https://www.github.com/unfetter-discover). 
+### Case 2: Build from local source files.  Developer Use Case
+
+You will first need to clone all the projects in [unfetter-discover](1).
 
 ```bash
  curl -s https://api.github.com/orgs/unfetter-discover/repos\?per_page\=200 | perl -ne 'print "$1\n" if (/"clone_url": "([^"]+)/)' | xargs -n 1 git clone
@@ -38,13 +49,22 @@ You will first need to clone all the projects in [unfetter-discover](https://www
 
 ### The Web Application
 
-The User Interface can be viewed after starting Docker Compose at the follow location:
+After running the `docker-compose` command you can view the application at:
 
-* [https://localhost/unfetter-discover-ui/](https://localhost/unfetter-discover-ui/)
-Unfetter-Discover will create certs and store them locally.  You will need to accept the certificates to move forward.
+https://localhost/unfetter-discover-ui/
 
-## License 
+> Note: If you receive a 404 error from nginx, ensure you include the trailing slash
+> on the URL
+
+Unfetter-Discover will create certs and store them locally. You will need to
+accept the certificates to move forward.
+
+## License
+
 See [LICENSE](LICENSE.md).
 
 ## Disclaimer
+
 See [DISCLAIMER](DISCLAIMER.md).
+
+[1] https://www.github.com/unfetter-discover


### PR DESCRIPTION
This commit updates documentation in README and adds a note about the trailing slash in the deployed app's URL - without it nginx serves a 404 error to the client.