### PR TITLE
Updated trailing slashes to fix redirects

### DIFF
--- a/config/nginx/conf.d/default.conf
+++ b/config/nginx/conf.d/default.conf
@@ -16,15 +16,15 @@ server {
   proxy_set_header X-Forwarded-Host $http_host;
   proxy_set_header X-Forwarded-Proto $scheme;
 
-  location /cti-stix-store-api {
-    proxy_pass http://cti-stix-store:3000/cti-stix-store-api;
+  location /cti-stix-store-api/ {
+    proxy_pass http://cti-stix-store:3000/cti-stix-store-api/;
   }
 
-  location /unfetter-discover-ui {
-    proxy_pass https://unfetter-discover-ui:4200/unfetter-discover-ui;
+  location /unfetter-discover-ui/ {
+    proxy_pass https://unfetter-discover-ui:4200/unfetter-discover-ui/;
   }
 
-  location /cti-stix-ui {
-    proxy_pass https://cti-stix-ui:4200/cti-stix-ui;
+  location /cti-stix-ui/ {
+    proxy_pass https://cti-stix-ui:4200/cti-stix-ui/;
   }
 }


### PR DESCRIPTION
Adding the trailing slashes to the proxy_pass adds the slash automatically and fixes the redirect.