### PR TITLE
load sample report by url

### DIFF
--- a/config/examples/unfetter-db/translation-config.json
+++ b/config/examples/unfetter-db/translation-config.json
@@ -1,17 +1,5 @@
 [
     {
-        "_id": "31d67373-ade0-4d5f-a2c5-1b75a66d0b8d",
-        "configKey": "adapter.rules.url",
-        "configValue": {
-            "systemName": "report-system",
-            "searchPattern": "https://(.*)\/(.*)$",
-            "replacementPattern": "https://domian.next/report/$2?accept=application/json"
-        },
-        "configGroups": [
-            "stixConfig"
-        ]
-    },
-    {
         "_id": "0d0886e1-fec2-4a62-80c5-5528ad3dd11e",
         "configKey": "adapter.rules.url",
         "configValue": {

--- a/config/examples/unfetter-db/translation-config.json
+++ b/config/examples/unfetter-db/translation-config.json
@@ -3,9 +3,21 @@
         "_id": "31d67373-ade0-4d5f-a2c5-1b75a66d0b8d",
         "configKey": "adapter.rules.url",
         "configValue": {
-            "systemName": "sample-report-system",
+            "systemName": "report-system",
             "searchPattern": "https://(.*)\/(.*)$",
             "replacementPattern": "https://domian.next/report/$2?accept=application/json"
+        },
+        "configGroups": [
+            "stixConfig"
+        ]
+    },
+    {
+        "_id": "0d0886e1-fec2-4a62-80c5-5528ad3dd11e",
+        "configKey": "adapter.rules.url",
+        "configValue": {
+            "systemName": "sample-report-system",
+            "searchPattern": "https://(.*)\/(.*)$",
+            "replacementPattern": "/api/ctf/translate/report/data/sample"
         },
         "configGroups": [
             "stixConfig"

--- a/config/examples/unfetter-db/translation-config.json
+++ b/config/examples/unfetter-db/translation-config.json
@@ -3,8 +3,8 @@
         "_id": "0d0886e1-fec2-4a62-80c5-5528ad3dd11e",
         "configKey": "adapter.rules.url",
         "configValue": {
-            "systemName": "sample-report-system",
-            "searchPattern": "https://(.*)\/(.*)$",
+            "systemName" : "sample-report-system",
+            "searchPattern" : "https://(.*)/?(.*)?$",
             "replacementPattern": "/api/ctf/translate/report/data/sample"
         },
         "configGroups": [


### PR DESCRIPTION
supports unfetter-discover/unfetter#340

## To Test
* Pull this code, restart unfetter stack
* In Mongo query for `db.getCollection('config').find({ 'configValue.systemName': 'sample-report-system' })`
* Verify the entry exists
