### PR TITLE
clean up nginx

### DIFF
--- a/config/nginx/conf.d.angular/default.conf
+++ b/config/nginx/conf.d.angular/default.conf
@@ -22,10 +22,6 @@ server {
     proxy_pass http://unfetter-discover-api-explorer:8080/docs/;
   }
   
-  location /api/ctf/parser/upload {
-    proxy_pass http://unfetter-ctf-ingest:10010/upload;
-  }
-  
   location /api/ {
     proxy_pass https://unfetter-discover-api:3000/;
   }

--- a/config/nginx/conf.d.aot/default.conf
+++ b/config/nginx/conf.d.aot/default.conf
@@ -18,10 +18,6 @@ server {
     proxy_pass http://unfetter-discover-api-explorer:8080/docs/;
   }
   
-  location /api/ctf/parser/upload {
-    proxy_pass http://unfetter-ctf-ingest:10010/upload;
-  }
-  
   location /api/ {
     proxy_pass https://unfetter-discover-api:3000/;
   }

--- a/config/nginx/conf.d.aot/gzip.conf
+++ b/config/nginx/conf.d.aot/gzip.conf
@@ -1,5 +1,0 @@
-gzip on;
-gzip_min_length 1100;
-gzip_buffers 4 32k;
-gzip_types application/javascript application/json application/x-javascript text/xml text/css text/plain image/svg image/svg+xml application/x-font-ttf application/vnd.api+json
-gzip_vary on;


### PR DESCRIPTION
## To test
* visit, /threat-dashboard/modify/
* click upload csv button
  * unfetter-store/unfetter-ctf-ingest/test-data/ctf-sample.csv is a good sample file
* the upload should still work, that proxy_pass removed was not really used
* verify the pages still load w/ gzip after removing the redundant gzip config
   * response headers should have, content-encoding:gzip