### PR TITLE
fixes #718, added new build startegy for docker compose images

### DIFF
--- a/build-docker-hub-images.sh
+++ b/build-docker-hub-images.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# This script is used to build the images that are pushed to Docker Hub
+# Requirements:
+# - `unfetter-ui` project in ../unfetter-ui directory
+# - nodejs
+# - docker-compose
+
+if ! command -v node &>/dev/null; then
+    echo "This script requires nodejs";
+    exit 1;
+fi
+
+if ! command -v docker-compose &>/dev/null; then
+    echo "This script requires docker-compose";
+    exit 1;
+fi
+
+if [ -d '../unfetter-ui' ]; then
+
+    # Build UI
+    cd ../unfetter-ui;
+    npm install;
+    npm run build:dev;
+
+    if [ ! -d 'dist' ]; then
+        echo "unfetter-ui did not build correctly";
+        exit 1;
+    fi
+
+    # Run docker compose
+    cd ../unfetter;
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        docker-compose -f docker-compose.build-docker-hub.yml build;
+    else
+        sudo docker-compose -f docker-compose.build-docker-hub.yml build;
+    fi
+else
+    echo "This script requires the unfetter-ui to be present as a sibling directory to unfetter.";
+fi

--- a/config/nginx/conf.d.dockerhub/default.conf
+++ b/config/nginx/conf.d.dockerhub/default.conf
@@ -1,0 +1,28 @@
+
+# include ./conf.d.extra/dn-map.conf;
+
+server {
+    listen         80;
+    return 301 https://$host$request_uri;
+}
+
+server {
+  include ./conf.d.extra/ssl-server.conf;
+
+  include ./conf.d.extra/gzip.conf;
+  include ./conf.d.extra/security-headers.conf;
+  # include ./conf.d.extra/ssl-client.conf;
+  # include ./conf.d.extra/dn-forbidden.conf;
+  
+  location /explorer/ {
+    proxy_pass http://unfetter-api-explorer:3200/;
+  }
+  
+  location /api/ {
+    proxy_pass https://unfetter-discover-api:3000/;
+  }
+
+  location / {
+    try_files $uri$args $uri$args/ /index.html;
+  }
+}

--- a/docker-compose.build-docker-hub.yml
+++ b/docker-compose.build-docker-hub.yml
@@ -1,0 +1,176 @@
+version: '2.0'
+services:
+  unfetter-discover-gateway:
+    image: nginx:1.13.5-alpine
+    container_name: unfetter-discover-gateway
+    ports:
+     - "443:443"
+     - "80:80"
+    depends_on:
+     - unfetter-discover-openssl
+    links:
+     - unfetter-api-explorer
+     - unfetter-discover-api
+    volumes:
+     - ./config/nginx/conf.d.dockerhub:/etc/nginx/conf.d
+     - ./config/nginx/conf.d.extra/:/etc/nginx/conf.d.extra
+     - ./certs/:/etc/pki/tls/certs
+     - ../unfetter-ui/dist:/etc/nginx/html
+
+  unfetter-discover-openssl:
+    image: svagi/openssl:latest
+    container_name: unfetter-discover-openssl
+    entrypoint:
+     - openssl
+     - req
+     - -subj
+     - /CN=localhost/DC=localhost/DC=localdomain
+     - -new
+     - -newkey
+     - rsa:2048
+     - -days
+     - "365"
+     - -nodes
+     - -x509
+     - -keyout
+     - /tmp/certs/server.key
+     - -out
+     - /tmp/certs/server.crt
+    volumes:
+     - ./certs/:/tmp/certs
+
+  unfetter-discover-processor:
+    build: ../unfetter-store/unfetter-discover-processor
+    container_name: unfetter-discover-processor
+    image: unfetter-discover-processor
+    volumes:
+     - ./config/examples:/tmp/examples
+    #  TODO find a working volume mounting
+     - ../unfetter-store/unfetter-discover-processor/processor.js:/usr/src/app/processor.js
+    environment:
+     - MONGO_HOST=repository
+     # If deployed in a proxy, add the proxy's URL here
+     - HTTPS_PROXY_URL=
+    entrypoint:
+     - node
+     - processor.js
+     - --stix
+     - /tmp/examples/unfetter-stix/stix.json
+     - --enhanced-stix-properties
+     - /tmp/examples/unfetter-db/stix-enhancements.json
+     - /tmp/examples/unfetter-db/stix-meta.json
+     - --config
+     - /tmp/examples/unfetter-db/config.json
+     - /tmp/examples/unfetter-db/translation-config.json
+     - --add-mitre-data
+     - "true"
+    depends_on:
+     - cti-stix-store-repository
+    links:
+     - cti-stix-store-repository:repository
+
+  # unfetter-ctf-ingest:
+  #   build: ../unfetter-store/unfetter-ctf-ingest
+  #   container_name: unfetter-ctf-ingest
+  #   image: unfetter-ctf-ingest
+  #   volumes:
+  #    - ../unfetter-store/unfetter-ctf-ingest/test-data:/tmp/test-data
+  #   environment:
+  #     - API_PROTOCOL=https
+  #     - API_HOST=apihost
+  #     - API_PORT=3000
+  #     - API_CONTEXT=/
+  #     - MONGO_REPOSITORY=repository
+  #     - MONGO_PORT=27017
+  #     - MONGO_DBNAME=stix
+  #   ports:
+  #   - "3001:10010"
+  #   entrypoint:
+  #    - npm
+  #    - start
+  #   depends_on:
+  #    - cti-stix-store-repository
+  #    - unfetter-discover-api
+  #   links:
+  #    - cti-stix-store-repository:repository
+  #    - unfetter-discover-api:apihost
+
+  cti-stix-store-repository:
+    image: mongo:3.4.1
+    container_name: cti-stix-store-repository
+    ports:
+    - "27018:27017"
+    volumes:
+    - ./data/db:/data/db
+
+  unfetter-api-explorer:
+    build: 
+      context: ../unfetter-store
+      dockerfile: unfetter-api-explorer/parent-context.Dockerfile
+    container_name: unfetter-api-explorer
+    image: unfetter-api-explorer
+    volumes:
+     - ../unfetter-store/unfetter-api-explorer/src:/usr/share/unfetter-api-explorer/src
+     - ../unfetter-store/unfetter-discover-api/multifile-remote.yaml:/usr/share/unfetter-discover-api/multifile-remote.yaml
+     - ../unfetter-store/unfetter-discover-api/api/swagger:/usr/share/unfetter-discover-api/api/swagger
+    ports:
+    - "3200:3200"
+    entrypoint:
+     - npm
+     - start
+
+  unfetter-discover-api:
+    build: ../unfetter-store/unfetter-discover-api
+    container_name: unfetter-discover-api
+    image: unfetter-discover-api
+    depends_on:
+    - unfetter-discover-openssl
+    - cti-stix-store-repository
+    links:
+    - cti-stix-store-repository:repository
+    - unfetter-pattern-handler
+    ports:
+    - "49360:3000"
+    - "5555:5555"
+    volumes:
+    - ./certs/:/etc/pki/tls/certs
+    - ../unfetter-store/unfetter-discover-api/test:/usr/share/unfetter-discover-api/test
+    - ../unfetter-store/unfetter-discover-api/api:/usr/share/unfetter-discover-api/api
+    - ../unfetter-store/unfetter-discover-api/app.js:/usr/share/unfetter-discover-api/app.js
+    environment:
+    - CTF_PARSE_HOST=http://unfetter-ctf-ingest
+    - PATTERN_HANDLER_DOMAIN = unfetter-pattern-handler
+    - PATTERN_HANDLER_PORT = 5000
+    - STIX_API_PROTOCOL=http
+    - STIX_API_HOST=cti-stix-store
+    - STIX_API_PORT=3000
+    - STIX_API_PATH=cti-stix-store-api
+    - MONGO_REPOSITORY=repository
+    - MONGO_PORT=27017
+    - MONGO_DBNAME=stix
+    - ENV=dev
+    # Options: UAC, TEST, DEMO
+    - RUN_MODE=DEMO
+    # If deployed in a proxy, add the proxy's URL here
+    - HTTPS_PROXY_URL=
+    # Options: true, false ; NOTE Always commit set to `false`
+    - SEND_EMAIL_ALERTS=false
+    entrypoint:
+    - npm
+    - run
+    - startdeploy
+
+  unfetter-pattern-handler:
+    build: ../stix2pattern
+    container_name: unfetter-pattern-handler
+    image: unfetter-pattern-handler
+    volumes:
+      - ../stix2pattern/app.py:/opt/stix/app.py
+      - ../stix2pattern/test.py:/opt/stix/test.py
+    ports:
+    - "5000:5000"
+    entrypoint:
+    # ["python3","app.py","0.0.0.0"]
+     - python3
+     - app.py
+     - 0.0.0.0

--- a/docker-compose.build-docker-hub.yml
+++ b/docker-compose.build-docker-hub.yml
@@ -69,31 +69,31 @@ services:
     links:
      - cti-stix-store-repository:repository
 
-  # unfetter-ctf-ingest:
-  #   build: ../unfetter-store/unfetter-ctf-ingest
-  #   container_name: unfetter-ctf-ingest
-  #   image: unfetter-ctf-ingest
-  #   volumes:
-  #    - ../unfetter-store/unfetter-ctf-ingest/test-data:/tmp/test-data
-  #   environment:
-  #     - API_PROTOCOL=https
-  #     - API_HOST=apihost
-  #     - API_PORT=3000
-  #     - API_CONTEXT=/
-  #     - MONGO_REPOSITORY=repository
-  #     - MONGO_PORT=27017
-  #     - MONGO_DBNAME=stix
-  #   ports:
-  #   - "3001:10010"
-  #   entrypoint:
-  #    - npm
-  #    - start
-  #   depends_on:
-  #    - cti-stix-store-repository
-  #    - unfetter-discover-api
-  #   links:
-  #    - cti-stix-store-repository:repository
-  #    - unfetter-discover-api:apihost
+  unfetter-ctf-ingest:
+    build: ../unfetter-store/unfetter-ctf-ingest
+    container_name: unfetter-ctf-ingest
+    image: unfetter-ctf-ingest
+    volumes:
+     - ../unfetter-store/unfetter-ctf-ingest/test-data:/tmp/test-data
+    environment:
+      - API_PROTOCOL=https
+      - API_HOST=apihost
+      - API_PORT=3000
+      - API_CONTEXT=/
+      - MONGO_REPOSITORY=repository
+      - MONGO_PORT=27017
+      - MONGO_DBNAME=stix
+    ports:
+    - "3001:10010"
+    entrypoint:
+     - npm
+     - start
+    depends_on:
+     - cti-stix-store-repository
+     - unfetter-discover-api
+    links:
+     - cti-stix-store-repository:repository
+     - unfetter-discover-api:apihost
 
   cti-stix-store-repository:
     image: mongo:3.4.1


### PR DESCRIPTION
Requirements
- `issue-718` branch on `unfetter` and `unfetter-ui`
- https://github.com/unfetter-discover/unfetter-ui/pull/235

Instructions
- Delete all containers and images
- Run the `build-docker-hub-images.sh`
- Confirm stack is running as expect for `DEMO` mode