### PR TITLE
Issue 762

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -54,6 +54,9 @@ services:
      - MONGO_HOST=repository
      # If deployed in a proxy, add the proxy's URL here
      - HTTPS_PROXY_URL=
+     # If using password protection, enter it here
+     - MONGO_USER=
+     - MONGO_PASSWORD=
     entrypoint:
      - node
      - processor.js
@@ -86,6 +89,9 @@ services:
       - MONGO_REPOSITORY=repository
       - MONGO_PORT=27017
       - MONGO_DBNAME=stix
+      # If using password protection, enter it here
+      - MONGO_USER=
+      - MONGO_PASSWORD=
     ports:
     - "3001:10010"
     entrypoint:
@@ -109,6 +115,9 @@ services:
       - MONGO_REPOSITORY=repository
       - MONGO_PORT=27017
       - MONGO_DBNAME=stix
+      # If using password protection, enter it here
+      - MONGO_USER=
+      - MONGO_PASSWORD=
       # If deployed in a proxy, add the proxy's URL here
       - HTTPS_PROXY_URL=
       # Options: true, false ; NOTE Always commit set to `false`
@@ -132,6 +141,8 @@ services:
     - "27018:27017"
     volumes:
     - ./data/db:/data/db
+    # Uncomment this if using authentication
+    # entrypoint: /entrypoint.sh mongod --auth
 
   unfetter-api-explorer:
     build: 
@@ -182,6 +193,9 @@ services:
     - MONGO_REPOSITORY=repository
     - MONGO_PORT=27017
     - MONGO_DBNAME=stix
+    # If using password protection, enter it here
+    - MONGO_USER=
+    - MONGO_PASSWORD=
     - ENV=dev
     # Options: UAC, TEST, DEMO
     - RUN_MODE=UAC


### PR DESCRIPTION
Requirements:

- issue-762 on `unfetter` and `unfetter-store`
https://github.com/unfetter-discover/unfetter-store/pull/94

Instructions:

- Issue the following command in mongo:

```
use stix
db.createUser( { user: "someusername",
pwd: "somepassword",
roles: [ "readWrite"] } )
```

- Stop stack
- Remove `unfetter-ctf-ingest` container and images
- Bring stack back up, confirm everything works as normal (this ensures mongo auth is still optional)
- Stop stack
- Make the following edits to `docker-compose.development.yml`:
- Uncomment `# entrypoint: /entrypoint.sh mongod --auth` in `cti-stix-store-repository`
- Make all 4 instances of `MONGO_USER`: `MONGO_USER=someusername`
- Make all 4 instances of `MONGO_PASSWORD`: `MONGO_USER=somepassword`
- Start stack, ensure everything works, ensure there are no authentication errors from any of the backend services