### PR TITLE
mongo pw handling

### DIFF
--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -54,6 +54,9 @@ services:
      - MONGO_HOST=repository
      # If deployed in a proxy, add the proxy's URL here
      - HTTPS_PROXY_URL=
+     # If using password protection, enter it here
+     - "MONGO_USER=${MONGO_USER}"
+     - "MONGO_PASSWORD=${MONGO_PASSWORD}"
     entrypoint:
      - node
      - processor.js
@@ -86,6 +89,9 @@ services:
       - MONGO_REPOSITORY=repository
       - MONGO_PORT=27017
       - MONGO_DBNAME=stix
+      # If using password protection, enter it here
+      - "MONGO_USER=${MONGO_USER}"
+      - "MONGO_PASSWORD=${MONGO_PASSWORD}"
     entrypoint:
      - npm
      - start
@@ -107,6 +113,9 @@ services:
       - MONGO_REPOSITORY=repository
       - MONGO_PORT=27017
       - MONGO_DBNAME=stix
+      # If using password protection, enter it here
+      - "MONGO_USER=${MONGO_USER}"
+      - "MONGO_PASSWORD=${MONGO_PASSWORD}"
     entrypoint:
      - npm
      - start
@@ -166,6 +175,9 @@ services:
     - MONGO_REPOSITORY=repository
     - MONGO_PORT=27017
     - MONGO_DBNAME=stix
+    # If using password protection, enter it here
+    - "MONGO_USER=${MONGO_USER}"
+    - "MONGO_PASSWORD=${MONGO_PASSWORD}"
     - ENV=dev
     # Options: UAC, TEST, DEMO
     - RUN_MODE=UAC

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -54,6 +54,9 @@ services:
      - MONGO_HOST=repository
      # If deployed in a proxy, add the proxy's URL here
      - HTTPS_PROXY_URL=
+     # If using password protection, enter it here
+     - "MONGO_USER=${MONGO_USER}"
+     - "MONGO_PASSWORD=${MONGO_PASSWORD}"
     entrypoint:
      - node
      - processor.js
@@ -86,6 +89,9 @@ services:
       - MONGO_REPOSITORY=repository
       - MONGO_PORT=27017
       - MONGO_DBNAME=stix
+      # If using password protection, enter it here
+      - "MONGO_USER=${MONGO_USER}"
+      - "MONGO_PASSWORD=${MONGO_PASSWORD}"
     ports:
     - "3001:10010"
     entrypoint:
@@ -109,6 +115,9 @@ services:
       - MONGO_REPOSITORY=repository
       - MONGO_PORT=27017
       - MONGO_DBNAME=stix
+      # If using password protection, enter it here
+      - "MONGO_USER=${MONGO_USER}"
+      - "MONGO_PASSWORD=${MONGO_PASSWORD}"
       # If deployed in a proxy, add the proxy's URL here
       - HTTPS_PROXY_URL=
       # Options: true, false ; NOTE Always commit set to `false`
@@ -184,6 +193,9 @@ services:
     - MONGO_REPOSITORY=repository
     - MONGO_PORT=27017
     - MONGO_DBNAME=stix
+    # If using password protection, enter it here
+    - "MONGO_USER=${MONGO_USER}"
+    - "MONGO_PASSWORD=${MONGO_PASSWORD}"
     - ENV=dev
     # Options: UAC, TEST, DEMO
     - RUN_MODE=UAC


### PR DESCRIPTION
Requires issue-762-2 on both `unfetter` and `unfetter-store`.

Related PR: https://github.com/unfetter-discover/unfetter-store/pull/98

---

MongoDB password configuration in Unfetter requires multiple steps.  Unfetter should be up and running before these steps are taken.

### 1. Add a user to the stix database

In a mongo shell, execute the following command:

```
use stix
db.createUser( { user: "<yourusername>",
pwd: "<yourpassword>",
roles: [ "readWrite"] } )
db.getCollection('stix').find({})
```

### 2. Stop the stack
### 3. Add `MONGO_USER=<yourusername>` and `MONGO_PASSWORD=<yourpassword>` environmental variables to the host system executing `docker-compose`
### 4. Enable the `--auth` flag for MongoDB in `docker-compose`

Uncomment the following line under `cti-stix-store-repository`: 

`# entrypoint: /entrypoint.sh mongod --auth`

### 5. Restart stack
