### PR TITLE
add modified date

### DIFF
--- a/config/examples/unfetter-stix/assessments3.stix.json
+++ b/config/examples/unfetter-stix/assessments3.stix.json
@@ -58,6 +58,8 @@
       "type" : "x-unfetter-object-assessment",
       "id" : "x-unfetter-object-assessment-4adf0a88-35a1-4502-bb81-bd41580b6663",
       "name" : "Sysmon Assessment",
+      "created": "2018-04-12T16:00:55.615Z",
+      "modified": "2018-04-12T16:00:55.615Z",
       "description" : "An assessment of Sysmon capabilities against MT CTF attack patterns",
       "created_by_ref": "identity--e240b257-5c42-402e-a0e8-7b81ecc1c09a",
       "object_ref" : "x-unfetter-capability--ce4171360-0cbf-4130-b01c-dea9ee4bae65",
@@ -3082,6 +3084,8 @@
       "name" : "Norton Assessment",
       "description" : "An assessment of Norton Antivirus capabilities against MT CTF attack patterns",
       "created_by_ref": "identity--e240b257-5c42-402e-a0e8-7b81ecc1c09a",
+      "created": "2018-04-12T16:00:55.615Z",
+      "modified": "2018-04-12T16:00:55.615Z",
       "object_ref" : "x-unfetter-capability--64e5efcb-86ea-47f4-bb1a-c4dc2ffc136e",
       "is_baseline" : "false",
       "set_ref" : [


### PR DESCRIPTION
## problem
fix the dates in the assess3 master list

## solution
added dates to test data on startup

## test
* pull this branch
* clear mongo
* restart stack
* verify the modified data is in mongo and in the ui under assess3 master list
* `db.getCollection('stix').find({'stix.type': 'x-unfetter-object-assessment'}, { 'stix.modified': 1 })`