### PR TITLE
Issue 955

### DIFF
--- a/config/examples/unfetter-stix/assessments3-categories.stix.json
+++ b/config/examples/unfetter-stix/assessments3-categories.stix.json
@@ -1,0 +1,315 @@
+{
+  "objects": [
+    {
+      "id": "x-unfetter-category--83e6d0fd-6672-42a4-a2d5-58f17a4b1381",
+      "type": "x-unfetter-category",
+      "name": "Network Analysis",
+      "description": "Network monitoring and analysis device.",
+      "created": "2018-04-12T16:00:55.616Z",
+      "created_by_ref": "identity--4ac44385-691d-411a-bda8-027c61d68e99",
+      "attack-patterns": [
+        {
+          "id": "attack-pattern--0f6c647a-8b42-4e1b-9904-bca5cfba3878",
+          "questions": [
+            {
+              "name": "mitigate",
+              "score": "M"
+            },
+            {
+              "name": "indicate",
+              "score": "S"
+            },
+            {
+              "name": "respond",
+              "score": "L"
+            }
+          ]
+        },
+        {
+          "id": "attack-pattern--21209e5f-53c7-4b7a-bbaf-f40a585b7bc4",
+          "questions": [
+            {
+              "name": "mitigate",
+              "score": "M"
+            },
+            {
+              "name": "indicate",
+              "score": "S"
+            },
+            {
+              "name": "respond",
+              "score": "L"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "x-unfetter-category--19cd220b-05b0-4fd4-9e53-0ba2cbf3add2",
+      "type": "x-unfetter-category",
+      "name": "Generic AV",
+      "description": "Generic anti virus software",
+      "created": "2018-04-12T16:00:55.616Z",
+      "created_by_ref": "identity--4ac44385-691d-411a-bda8-027c61d68e99",
+      "attack-patterns": [
+        {
+          "id": "attack-pattern--0f6c647a-8b42-4e1b-9904-bca5cfba3878",
+          "questions": [
+            {
+              "name": "mitigate",
+              "score": "M"
+            },
+            {
+              "name": "indicate",
+              "score": "S"
+            },
+            {
+              "name": "respond",
+              "score": "L"
+            }
+          ]
+        },
+        {
+          "id": "attack-pattern--21209e5f-53c7-4b7a-bbaf-f40a585b7bc4",
+          "questions": [
+            {
+              "name": "mitigate",
+              "score": "M"
+            },
+            {
+              "name": "indicate",
+              "score": "S"
+            },
+            {
+              "name": "respond",
+              "score": "L"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "x-unfetter-category--07535ddb-899c-40ca-a08b-d08691689511",
+      "type": "x-unfetter-category",
+      "name": "Standard EDR",
+      "description": "Generic endpoint detection and response tool.",
+      "created": "2018-04-12T16:00:55.616Z",
+      "created_by_ref": "identity--4ac44385-691d-411a-bda8-027c61d68e99",
+      "attack-patterns": [
+        {
+          "id": "attack-pattern--0f6c647a-8b42-4e1b-9904-bca5cfba3878",
+          "questions": [
+            {
+              "name": "mitigate",
+              "score": "M"
+            },
+            {
+              "name": "indicate",
+              "score": "S"
+            },
+            {
+              "name": "respond",
+              "score": "L"
+            }
+          ]
+        },
+        {
+          "id": "attack-pattern--21209e5f-53c7-4b7a-bbaf-f40a585b7bc4",
+          "questions": [
+            {
+              "name": "mitigate",
+              "score": "M"
+            },
+            {
+              "name": "indicate",
+              "score": "S"
+            },
+            {
+              "name": "respond",
+              "score": "L"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "x-unfetter-category--a746e3b0-0e4a-439e-a2e1-e33105f6bada",
+      "type": "x-unfetter-category",
+      "name": "Enterprise SIEM",
+      "description": "Enterprise SIEM",
+      "created": "2018-04-12T16:00:55.616Z",
+      "created_by_ref": "identity--4ac44385-691d-411a-bda8-027c61d68e99",
+      "attack-patterns": [
+        {
+          "id": "attack-pattern--0f6c647a-8b42-4e1b-9904-bca5cfba3878",
+          "questions": [
+            {
+              "name": "mitigate",
+              "score": "M"
+            },
+            {
+              "name": "indicate",
+              "score": "S"
+            },
+            {
+              "name": "respond",
+              "score": "L"
+            }
+          ]
+        },
+        {
+          "id": "attack-pattern--21209e5f-53c7-4b7a-bbaf-f40a585b7bc4",
+          "questions": [
+            {
+              "name": "mitigate",
+              "score": "M"
+            },
+            {
+              "name": "indicate",
+              "score": "S"
+            },
+            {
+              "name": "respond",
+              "score": "L"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "x-unfetter-category--987e35d3-b8a4-45e2-a56b-c3fbf2ed14d2",
+      "type": "x-unfetter-category",
+      "name": "Network Firewall",
+      "description": "Network firewall device",
+      "created": "2018-04-12T16:00:55.616Z",
+      "created_by_ref": "identity--4ac44385-691d-411a-bda8-027c61d68e99",
+      "attack-patterns": [
+        {
+          "id": "attack-pattern--0f6c647a-8b42-4e1b-9904-bca5cfba3878",
+          "questions": [
+            {
+              "name": "mitigate",
+              "score": "M"
+            },
+            {
+              "name": "indicate",
+              "score": "S"
+            },
+            {
+              "name": "respond",
+              "score": "L"
+            }
+          ]
+        },
+        {
+          "id": "attack-pattern--21209e5f-53c7-4b7a-bbaf-f40a585b7bc4",
+          "questions": [
+            {
+              "name": "mitigate",
+              "score": "M"
+            },
+            {
+              "name": "indicate",
+              "score": "S"
+            },
+            {
+              "name": "respond",
+              "score": "L"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "x-unfetter-category--77815162-52a2-4ce6-b5ad-b88105b6f63d",
+      "type": "x-unfetter-category",
+      "name": "Autoruns",
+      "description": "This utility shows the user what programs are configured to run during system bootup or login, and/or on execution of various built-in Windows applications like Internet Explorer, Explorer and media players. These programs and drivers include ones in your startup folder, Run, RunOnce, and other Registry keys. Autoruns reports Explorer shell extensions, toolbars, browser helper objects, Winlogon notifications, auto-start services, etc.",
+      "created": "2018-04-12T16:00:55.616Z",
+      "created_by_ref": "identity--4ac44385-691d-411a-bda8-027c61d68e99",
+      "attack-patterns": [
+        {
+          "id": "attack-pattern--0f6c647a-8b42-4e1b-9904-bca5cfba3878",
+          "questions": [
+            {
+              "name": "mitigate",
+              "score": "M"
+            },
+            {
+              "name": "indicate",
+              "score": "S"
+            },
+            {
+              "name": "respond",
+              "score": "L"
+            }
+          ]
+        },
+        {
+          "id": "attack-pattern--21209e5f-53c7-4b7a-bbaf-f40a585b7bc4",
+          "questions": [
+            {
+              "name": "mitigate",
+              "score": "L"
+            },
+            {
+              "name": "indicate",
+              "score": "L"
+            },
+            {
+              "name": "respond",
+              "score": "L"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "x-unfetter-category--a752dd34-8bc7-4267-8872-ca29369c9d1f",
+      "type": "x-unfetter-category",
+      "name": "sysmon",
+      "description": "System Monitor (Sysmon) is a Windows system service and device driver that, once installed on a system, remains resident across system reboots to monitor and log system activity to the Windows event log. It provides detailed information about process creations, network connections, and changes to file creation time. By collecting the events it generates using Windows Event Collection or SIEM agents and subsequently analyzing them, you can identify malicious or anomalous activity and understand how intruders and malware operate on your network.",
+      "created": "2018-04-12T16:00:55.616Z",
+      "created_by_ref": "identity--4ac44385-691d-411a-bda8-027c61d68e99",
+      "attack-patterns": [
+        {
+          "id": "attack-pattern--0f6c647a-8b42-4e1b-9904-bca5cfba3878",
+          "questions": [
+            {
+              "name": "mitigate",
+              "score": "M"
+            },
+            {
+              "name": "indicate",
+              "score": "S"
+            },
+            {
+              "name": "respond",
+              "score": "L"
+            }
+          ]
+        },
+        {
+          "id": "attack-pattern--21209e5f-53c7-4b7a-bbaf-f40a585b7bc4",
+          "questions": [
+            {
+              "name": "mitigate",
+              "score": "M"
+            },
+            {
+              "name": "indicate",
+              "score": "S"
+            },
+            {
+              "name": "respond",
+              "score": "L"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "type": "bundle",
+  "id": "stix-archive-bundle",
+  "spec_version": "2.0"
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,7 @@ services:
      - /tmp/examples/unfetter-stix/stix.json
      - /tmp/examples/unfetter-stix/reports.stix.json
      #- /tmp/examples/unfetter-stix/ntctf-attack-patterns.stix.json
+     #- /tmp/examples/unfetter-stix/assessments3-categories.stix.json
      - /tmp/examples/unfetter-stix/assessments3.stix.json
      - /tmp/examples/unfetter-stix/sightings.stix.json
      - --enhanced-stix-properties


### PR DESCRIPTION
supports unfetter-discover/unfetter#955

# problem
* need sample assessment category data

# changed
* added sample assessment category data, but commented out for now

# to test
* pull this pr
* remove your mongo stix collection
* uncomment the ntctf and category test files in the processor section of `docker-compose.yml`
```
     #- /tmp/examples/unfetter-stix/ntctf-attack-patterns.stix.json
     #- /tmp/examples/unfetter-stix/assessments3-categories.stix.json
```
* restart the stack
* verify mongo 
```
db.getCollection('stix').find({'stix.type': 'x-unfetter-category'})
``` 