### PR TITLE
taxii integration

### DIFF
--- a/config/examples/unfetter-db/taxii.config.json
+++ b/config/examples/unfetter-db/taxii.config.json
@@ -1,0 +1,69 @@
+[
+    {
+        "_id": "577aacc9-67f6-4fb9-983f-e1719512d3a0",
+        "configKey": "taxiiCollections",
+        "configValue": [
+            {
+                "id": "95ecc380-afe9-11e4-9b6c-751b66dd541e",
+                "title": "Enterprise ATT&CK",
+                "description": "This data collection holds STIX objects from Enterprise ATT&CK"
+            },
+            {
+                "id": "062767bd-02d2-4b72-84ba-56caef0f8658",
+                "title": "Pre-ATT&CK",
+                "description": "This data collection holds STIX objects from Pre-ATT&CK"
+            },
+            {
+                "id": "2f669986-b40b-4423-b720-4396ca6a462b",
+                "title": "Mobile ATT&CK",
+                "description": "This data collection holds STIX objects from Mobile ATT&CK"
+            }
+        ]
+    },
+    {
+        "_id": "e6e8e894-8fe8-44da-8b8b-91cb126ce03f",
+        "configKey": "taxiiConfig",
+        "configValue": {
+            "port": 3002,
+            "accepts": [
+                "application/vnd.oasis.taxii+json; version=2.0",
+                "application/vnd.oasis.taxii+json",
+                "application/vnd.oasis.stix+json; version=2.0",
+                "application/vnd.oasis.stix+json"
+            ],
+            "connection_string": "mongodb://repository:27017/",
+            "response_type": {
+                "taxii": "application/vnd.oasis.taxii+json; version=2.0",
+                "stix": "application/vnd.oasis.stix+json; version=2.0"
+            },
+            "bundle_spec_version": "2.0",
+            "discovery": {
+                "title": "CTI TAXII server",
+                "description": "This TAXII server contains a listing of ATT&CK domain collections expressed as STIX, including PRE-ATT&CK, ATT&CK for Enterprise, and ATT&CK Mobile.",
+                "contact": "attack@mitre.org",
+                "default": "stix",
+                "api_roots": [
+                    "stix"
+                ]
+            },
+            "autogenerate_roots": {
+                "enabled": 1,
+                "versions": [
+                    "taxii-2.0"
+                ],
+                "max_content_length": "10485760"
+            },
+            "roots": [
+                {
+                    "title": "Default API root",
+                    "description": "This API root contains...",
+                    "versions": [
+                        "taxii-2.0"
+                    ],
+                    "max_content_length": "10485760",
+                    "path": "stix"
+                }
+            ]
+        }
+    }
+]

--- a/config/nginx/default.conf
+++ b/config/nginx/default.conf
@@ -24,6 +24,7 @@ server {
   # these conf files do not exist in name in the source repo
   #   they are specifically mapped based on the docker compose used
   include ./conf.d.runmode/runmode-locations.conf;
+  include ./conf.d.runmode/taxii.conf;
   include ./conf.d.runmode/ui.conf;
 }
 

--- a/config/nginx/taxii.conf
+++ b/config/nginx/taxii.conf
@@ -1,0 +1,3 @@
+location /taxii-server/ {
+    proxy_pass https://unfetter-taxii-server:3002/;
+}

--- a/docker-compose.taxii.development.yml
+++ b/docker-compose.taxii.development.yml
@@ -1,0 +1,24 @@
+version: '3.3'
+services:
+  unfetter-discover-gateway:
+    image: nginx:1.13.5-alpine
+    container_name: unfetter-discover-gateway
+    links:
+     - unfetter-taxii-server
+    volumes:
+     - ./config/nginx/taxii.conf:/etc/nginx/conf.d.runmode/taxii.conf
+
+  unfetter-taxii-server:
+    build: ../taxii-server
+    container_name: unfetter-taxii-server
+    image: unfetter-taxii-server
+    links:
+     - cti-stix-store-repository:repository
+    ports:
+     - "13002:3002"
+    volumes:
+     - ../taxii-server/src:/usr/share/unfetter-taxii-server/src
+     - ./certs/:/etc/pki/tls/certs
+    entrypoint:
+     - npm
+     - start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,7 @@ services:
      - --config
      - /tmp/examples/unfetter-db/config.json
      - /tmp/examples/unfetter-db/translation-config.json
+     - /tmp/examples/unfetter-db/taxii.config.json
      - --mitre-attack-data
      - enterprise
      - --auto-publish

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
      - ./config/nginx/default.conf:/etc/nginx/conf.d/default.conf
      - ./config/nginx/conf.d.extra/:/etc/nginx/conf.d.extra
      - ./config/nginx/blank.conf:/etc/nginx/conf.d.runmode/runmode-locations.conf
+     - ./config/nginx/taxii-blank.conf:/etc/nginx/conf.d.runmode/taxii.conf
      - ./config/nginx/ui-prod.conf:/etc/nginx/conf.d.runmode/ui.conf
      - ./certs/:/etc/pki/tls/certs
 


### PR DESCRIPTION
Requirements: `issue-1000` on `unfetter` and `taxii-server` -- Odds are, you probably don't have taxii-server cloned

Associated PR: https://github.com/unfetter-discover/taxii-server/pull/2

Instructions
- Bring up the stack with the taxii-server via: `docker-compose -f docker-compose.yml -f docker-compose.development.yml -f docker-compose.taxii.development.yml up`
- Ensure TAXII server works with the following command:
```
curl -k -X GET \
  https://localhost/taxii-server/stix \
  -H 'Cache-Control: no-cache' \
  -H 'Postman-Token: 2f385e10-596b-4263-ab59-badd2e2aa12a' \
  -H 'accept: application/vnd.oasis.taxii+json; version=2.0' \
  -H 'content-type: application/vnd.oasis.taxii+json; charset=utf-8; version=2.0'
```
- Unsure the rest of Unfetter works as expected
- Stop stack
- Start stack *without* the taxii-server `docker-compose -f docker-compose.yml -f docker-compose.development.yml up`
- Ensure Unfetter works as expected
- NOTE if running the UI locally, you may need to restart the UI server

fixes #1000 
