### PR TITLE
Issue 1065

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,12 +49,16 @@ services:
   unfetter-discover-processor:
     image: unfetter/unfetter-discover-processor:0.3.6
     container_name: unfetter-discover-processor
+    links:
+    - unfetter-pattern-handler
     volumes:
      - ./config/examples:/tmp/examples
     environment:
-     - MONGO_HOST=repository
-     # If deployed in a proxy, add the proxy's URL here
-     - HTTPS_PROXY_URL=
+    - PATTERN_HANDLER_DOMAIN=unfetter-pattern-handler
+    - PATTERN_HANDLER_PORT=5000
+    - MONGO_HOST=repository
+    # If deployed in a proxy, add the proxy's URL here
+    - HTTPS_PROXY_URL=
     entrypoint:
      - ts-node
      - src/app.ts
@@ -135,9 +139,8 @@ services:
     - unfetter-discover-openssl
     - cti-stix-store-repository
     links:
-     - cti-stix-store-repository:repository
-     - unfetter-pattern-handler
-     
+    - cti-stix-store-repository:repository
+    - unfetter-pattern-handler     
     volumes:
     - ./certs/:/etc/pki/tls/certs
     environment:
@@ -154,8 +157,8 @@ services:
     - RUN_MODE=DEMO
     # If deployed in a proxy, add the proxy's URL here
     - HTTPS_PROXY_URL=
-    - PATTERN_HANDLER_DOMAIN = unfetter-pattern-handler
-    - PATTERN_HANDLER_PORT = 5000
+    - PATTERN_HANDLER_DOMAIN=unfetter-pattern-handler
+    - PATTERN_HANDLER_PORT=5000
     entrypoint:
     - npm
     - start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,6 +83,8 @@ services:
      - enterprise
      - --auto-publish
      - "true"
+     - --auto-validate-patterns
+     - "true"
      # Interval options: daily, weekly, monthly
     #  - --interval
     #  - daily
@@ -167,7 +169,9 @@ services:
     image: unfetter/unfetter-pattern-handler:0.3.6
     container_name: unfetter-pattern-handler
     entrypoint:
-    # ["python3","app.py","0.0.0.0"]
-     - python3
-     - app.py
-     - 0.0.0.0
+    - gunicorn
+    - --config
+    - /opt/stix/gunicorn_config.py
+    - --access-logfile
+    - "-"
+    - app:app


### PR DESCRIPTION
Requires `issue-1065` on `unfetter`, `unfetter-store`, `unfetter-ui` and `stix2pattern`

Associated PRs:
- https://github.com/unfetter-discover/unfetter-ui/pull/465
- https://github.com/unfetter-discover/unfetter-store/pull/173
- https://github.com/unfetter-discover/stix2pattern/pull/21

Instructions:
- Delete stix collection from mongo: `db.getCollection('stix').remove({})`
- Rebuild stack
- Confirm that the stix2pattern api was hit by the processor during ingest: Run the following query: `db.getCollection('stix').find({_id: 'indicator--ede3b60f-d0c2-4c39-b1c7-8d094c7f92cf'})` - Confirm that the metaProperties for queries, validStixPattern, and observedData were populated
- Go to analytic exchange
- Create an analytic with a valid STIX pattern in the `Pseudocode` field, ie `[process:pid=3]`
- In the list view, verify that it has a `Valid Stix Pattern` message next to the `Pseudocode`
- Open filters, click the `Show STIX Patterns Only` checkbox at the bottom, confirm that the correct results were displayed

NOTE: The deployment model of stix2pattern was changed for this PR, be sure it's working properly

fixes #1065 
fixes #1078 