### PR TITLE
release scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ test-certs/output/*
 data/db/*
 # need at least one file in the folder
 !data/db/.gitkeep
+docker-hub.pass.txt

--- a/docker-compose.build-docker-hub.yml
+++ b/docker-compose.build-docker-hub.yml
@@ -71,3 +71,23 @@ services:
     volumes:
       - ../stix2pattern/app.py:/opt/stix/app.py
       - ../stix2pattern/test.py:/opt/stix/test.py
+
+  unfetter-socket-server:
+    build: ../unfetter-store/unfetter-socket-server
+    container_name: unfetter-socket-server
+    image: unfetter-socket-server
+    volumes:
+      - ../unfetter-store/unfetter-socket-server/src:/usr/share/unfetter-socket-server/src
+      - ./certs/:/etc/pki/tls/certs
+      - ../unfetter-store/unfetter-socket-server/config/private:/usr/share/unfetter-socket-server/config/private
+    environment:
+      - MONGO_REPOSITORY=repository
+      - MONGO_PORT=27017
+      - MONGO_DBNAME=stix
+    entrypoint:
+     - npm
+     - start
+    depends_on:
+     - cti-stix-store-repository
+    links:
+     - cti-stix-store-repository:repository

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,8 +45,6 @@ services:
      - /tmp/certs/server.crt
     volumes:
      - ./certs/:/tmp/certs
-    cap_drop:
-    - ALL
 
   unfetter-discover-processor:
     image: unfetter/unfetter-discover-processor:0.3.7
@@ -94,9 +92,6 @@ services:
      - cti-stix-store-repository
     links:
      - cti-stix-store-repository:repository
-    cap_drop:
-    - ALL
-
 
   unfetter-ctf-ingest:
     container_name: unfetter-ctf-ingest
@@ -118,9 +113,6 @@ services:
     links:
      - cti-stix-store-repository:repository
      - unfetter-discover-api:apihost
-    cap_drop:
-    - ALL
-
      
   cti-stix-store-repository:
     image: mongo:3.4.1
@@ -132,12 +124,6 @@ services:
     - ./data/db:/data/db
     # Uncomment this if using authentication
     # entrypoint: /entrypoint.sh mongod --auth
-    cap_drop:
-    - ALL
-    cap_add:
-    - CHOWN
-    - SETUID
-    - SETGID
 
   unfetter-api-explorer:
     image: unfetter/unfetter-api-explorer:0.3.7
@@ -147,9 +133,6 @@ services:
     entrypoint:
      - npm
      - start
-    cap_drop:
-    - ALL
-
 
   unfetter-discover-api:
     image: unfetter/unfetter-discover-api:0.3.7
@@ -181,9 +164,6 @@ services:
     entrypoint:
     - npm
     - start
-    cap_drop:
-    - ALL
-
 
   unfetter-pattern-handler:
     image: unfetter/unfetter-pattern-handler:0.3.7
@@ -195,6 +175,3 @@ services:
     - --access-logfile
     - "-"
     - app:app
-    cap_drop:
-    - ALL
-

--- a/release-scripts/docker-hub-login.sh
+++ b/release-scripts/docker-hub-login.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+cat ./docker-hub.pass.txt | docker login --username $USER --password-stdin

--- a/release-scripts/push-docker-ui.sh
+++ b/release-scripts/push-docker-ui.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+containers=(unfetter-discover-gateway)
+for container in ${containers[@]};
+do
+  echo "Pushing $container:$1"
+  docker push unfetter/$container:$1
+done

--- a/release-scripts/push-docker.sh
+++ b/release-scripts/push-docker.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+containers=(unfetter-ctf-ingest unfetter-discover-api unfetter-pattern-handler unfetter-discover-processor unfetter-api-explorer unfetter-ui unfetter-socket-server)
+for container in ${containers[@]};
+do
+  echo "Pushing $container:$1"
+  docker push unfetter/$container:$1
+done

--- a/release-scripts/tag-docker-ui.sh
+++ b/release-scripts/tag-docker-ui.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+containers=(unfetter-discover-gateway)
+for container in ${containers[@]};
+do
+  echo "Tagging $container to version $1"
+  docker tag $container unfetter/$container:$1
+done

--- a/release-scripts/tag-docker.sh
+++ b/release-scripts/tag-docker.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+containers=(unfetter-ctf-ingest unfetter-discover-api unfetter-pattern-handler unfetter-discover-processor unfetter-api-explorer unfetter-ui unfetter-socket-server)
+for container in ${containers[@]};
+do
+  echo "Tagging $container to version $1"
+  docker tag $container unfetter/$container:$1
+done


### PR DESCRIPTION
## problem
need to version and store release build scripts

## changes
added release scripts, *not* the passwd file, and `.gitignore` on the passwd file
added socket-server into the build

## test
* fetch this pr
* docker images
* clean out your images
* run `build-docker-hub.sh`
* verify images with `docker images`
* `./release-scripts/tag-docker.sh 9.9.9`
* verify tags with `docker images`
optionally docker login and try the push scripts