### PR TITLE
updated demo data

### DIFF
--- a/config/examples/unfetter-stix/assessments3/object-assessments.stix.json
+++ b/config/examples/unfetter-stix/assessments3/object-assessments.stix.json
@@ -12,7 +12,7 @@
       "description": "An assessment of Sysmon capabilities against NTCTF CTF attack patterns",
       "created_by_ref": "identity--e240b257-5c42-402e-a0e8-7b81ecc1c09a",
       "object_ref": "x-unfetter-capability--ce4171360-0cbf-4130-b01c-dea9ee4bae65",
-      "assessment_objects": [
+      "assessed_objects": [
         {
           "assessed_object_ref": "attack-pattern--bc63873f-bdd5-44f7-969e-e0a1414e42c4",
           "questions": [
@@ -75,7 +75,7 @@
       "created": "2018-04-12T16:00:55.615Z",
       "modified": "2018-04-12T16:00:55.615Z",
       "object_ref": "x-unfetter-capability--d03921e1-2113-406d-912a-d3e8d9981e56",
-      "assessment_objects": [
+      "assessed_objects": [
         {
           "assessed_object_ref": "attack-pattern--bc63873f-bdd5-44f7-969e-e0a1414e42c4",
           "questions": [
@@ -138,7 +138,7 @@
       "created": "2018-04-12T16:00:55.615Z",
       "modified": "2018-04-12T16:00:55.615Z",
       "object_ref": "x-unfetter-capability--64e5efcb-86ea-47f4-bb1a-c4dc2ffc136e",
-      "assessment_objects": [
+      "assessed_objects": [
         {
           "assessed_object_ref": "attack-pattern--bc63873f-bdd5-44f7-969e-e0a1414e42c4",
           "questions": [
@@ -201,7 +201,7 @@
       "created": "2018-04-12T16:00:55.615Z",
       "modified": "2018-04-12T16:00:55.615Z",
       "object_ref": "x-unfetter-capability--46d585a6-7480-415c-b29b-5c719934f519",
-      "assessment_objects": [
+      "assessed_objects": [
         {
           "assessed_object_ref": "attack-pattern--bc63873f-bdd5-44f7-969e-e0a1414e42c4",
           "questions": [


### PR DESCRIPTION
*Merge into develop only!*

## problem
demo data was old and caused some screens to fail

## changes
changed property to assessed_objects

## test
* clean mongo `stix.remove({})`
* restart stack
* create an assessment with a demo capability, the full result tab should load
