### PR TITLE
Using templates to build the default.conf on the fly.  Fixed #1028

### DIFF
--- a/ansible/roles/gateway/files/conf.d/default.conf
+++ b/ansible/roles/gateway/files/conf.d/default.conf
@@ -1,0 +1,42 @@
+# include ./conf.d.extra/dn-map.conf;
+# This is a test to see if the template is updated
+server {
+    listen         80;
+    return 301 https://$host$request_uri;
+}
+
+server {
+  include ./conf.d.extra/ssl-server.conf;
+
+  include ./conf.d.extra/gzip.conf;
+  include ./conf.d.extra/security-headers.conf;
+  # include ./conf.d.extra/ssl-client.conf;
+  # include ./conf.d.extra/dn-forbidden.conf;
+  
+  location /explorer/ {
+    proxy_pass http://unfetter-api-explorer:3200/;
+  }
+  
+  location /api/ {
+    proxy_pass https://unfetter-discover-api:3000/;
+  }
+
+  # these conf files do not exist in name in the source repo
+  #   they are specifically mapped based on the docker compose used
+    
+  
+  location /socketserver/ {
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_http_version 1.1;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $host;
+    proxy_pass https://unfetter-socket-server:3333/socket/;
+  }
+  
+  
+  location / {
+    proxy_pass https://unfetter-ui:80;
+  }
+  
+}

--- a/ansible/roles/gateway/tasks/main.yml
+++ b/ansible/roles/gateway/tasks/main.yml
@@ -28,6 +28,13 @@
     path: "{{ role_path }}/files"
   when: "('production' in group_names and build_action=='local')"
 
+- name: "Build new template"
+  template: 
+    src: '{{ role_path }}/templates/default.j2'
+    dest: '{{ role_path }}/files/conf.d/default.conf'
+    force: true
+# when: Unsure when to do this, I guess every time this needs to get deployed.    
+
 # Creates the docker container for the gateway
 - name: Create the {{ container_name }} from image {{ image_name }}
   docker_container:
@@ -44,17 +51,17 @@
     - "80:80"
     links: "{{ link_list }}"
     volumes: 
-     - "{{ prepath }}/unfetter/config/nginx/default.conf:/etc/nginx/conf.d/default.conf"
+     - "{{ role_path }}/files/conf.d/default.conf:/etc/nginx/conf.d/default.conf"
      - "{{ prepath }}/unfetter/config/nginx/conf.d.extra/:/etc/nginx/conf.d.extra"
 #     - "{{ prepath }}/unfetter/config/certs/:/etc/pki/tls/certs"
      - "certs:/etc/pki/tls:ro"
   # TAXII
-     - "{{ prepath }}/unfetter/config/nginx/{{ 'taxii.conf' if use_taxii else 'taxii-blank.conf' }}:/etc/nginx/conf.d.runmode/taxii.conf"
-     - "{{ prepath }}/unfetter/config/nginx/{{ 'taxii-auth.conf' if use_taxii and use_taxii_tls else 'taxii-auth-blank.conf' }}:/etc/nginx/conf.d.runmode/taxii-auth.conf"
+  #   - "{{ prepath }}/unfetter/config/nginx/{{ 'taxii.conf' if use_taxii else 'taxii-blank.conf' }}:/etc/nginx/conf.d.runmode/taxii.conf"
+  #   - "{{ prepath }}/unfetter/config/nginx/{{ 'taxii-auth.conf' if use_taxii and use_taxii_tls else 'taxii-auth-blank.conf' }}:/etc/nginx/conf.d.runmode/taxii-auth.conf"
    # In UAC
-     - "{{ prepath }}/unfetter/config/nginx/{{ 'uac-locations.conf' if use_uac else 'blank.conf' }}:/etc/nginx/conf.d.runmode/runmode-locations.conf"
+  #   - "{{ prepath }}/unfetter/config/nginx/{{ 'uac-locations.conf' if use_uac else 'blank.conf' }}:/etc/nginx/conf.d.runmode/runmode-locations.conf"
    # In USE_UNFETTER_UI
-     - "{{ prepath }}/unfetter/config/nginx/{{ 'ui-dev.conf' if use_unfetter_ui else 'ui-prod.conf' }}:/etc/nginx/conf.d.runmode/ui.conf"
+  #   - "{{ prepath }}/unfetter/config/nginx/{{ 'ui-dev.conf' if use_unfetter_ui else 'ui-prod.conf' }}:/etc/nginx/conf.d.runmode/ui.conf"
   when: run_action
 
   

--- a/ansible/roles/gateway/templates/default.j2
+++ b/ansible/roles/gateway/templates/default.j2
@@ -1,0 +1,90 @@
+# include ./conf.d.extra/dn-map.conf;
+# This is a test to see if the template is updated
+server {
+    listen         80;
+    return 301 https://$host$request_uri;
+}
+
+server {
+  include ./conf.d.extra/ssl-server.conf;
+
+  include ./conf.d.extra/gzip.conf;
+  include ./conf.d.extra/security-headers.conf;
+  # include ./conf.d.extra/ssl-client.conf;
+  # include ./conf.d.extra/dn-forbidden.conf;
+  
+  location /explorer/ {
+    proxy_pass http://unfetter-api-explorer:3200/;
+  }
+  
+  location /api/ {
+    proxy_pass https://unfetter-discover-api:3000/;
+  }
+
+  # these conf files do not exist in name in the source repo
+  #   they are specifically mapped based on the docker compose used
+  {% if use_taxii %}
+  location /taxii-server/ {
+    proxy_pass https://unfetter-taxii-server:3002/;
+  }
+  {% endif %}
+  
+  {% if use_uac %}
+
+  location /socketserver/ {
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_http_version 1.1;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $host;
+    proxy_pass https://unfetter-socket-server:3333/socket/;
+  }
+  {% endif %}
+
+  {% if use_unfetter_ui %}
+
+  location / {
+    proxy_pass https://unfetter-ui:80;
+  }
+  {% else %}
+  location / {
+    try_files $uri$args $uri$args/ /index.html;
+  }
+  {% endif %}
+
+}
+{% if use_taxii %}
+server {
+  listen 8443 ssl;
+  listen [::]:8443 ssl;
+  ssl_protocols TLSv1.2;
+  ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
+
+  ssl_prefer_server_ciphers on;
+  ssl_session_timeout 5m;
+  ssl_session_cache shared:SSL:50m;
+  ssl_session_tickets off;
+
+  ssl_certificate         /etc/pki/tls/certs/server-crt.pem;
+  ssl_certificate_key     /etc/pki/tls/certs/server-key.pem;
+  ssl_client_certificate  /etc/pki/tls/certs/ca_client-crt.pem;
+  # ssl_certificate         /etc/pki/tls/certs/rootCA.pem;
+  # ssl_certificate_key     /etc/pki/tls/certs/rootCA.key;
+  # ssl_client_certificate  /etc/pki/tls/certs/client.crt;
+
+  # ssl_verify_client optional_no_ca; # | optional | off | on
+  ssl_verify_client on;
+  ssl_verify_depth 1;
+
+  proxy_set_header X-Forwarded-Host $http_host;
+  proxy_set_header X-Forwarded-Proto $scheme;
+  proxy_set_header X-SSL-CERT $ssl_client_cert;
+  proxy_set_header X-SSL-Client-S-DN   $ssl_client_s_dn;
+
+  location / {
+      proxy_pass https://unfetter-taxii-server:3002/;
+  }
+}
+
+
+{% endif %}


### PR DESCRIPTION
Now, the default.conf is built on the fly based on what the target build process is