### PR TITLE
Issue 1268

### DIFF
--- a/ansible/build-prod.yml
+++ b/ansible/build-prod.yml
@@ -7,6 +7,7 @@
 
 - name: Build the Docker images only.  Do not 
   hosts: build
+  become: true
   tasks:
   - name: Iterate over group variables
     debug:

--- a/ansible/deploy-prod.yml
+++ b/ansible/deploy-prod.yml
@@ -7,6 +7,7 @@
 
 - name: Build Playbook
   hosts: prod
+  become: true
   tasks:
                    
   - name: Start running the commands

--- a/ansible/discover-tasks.yml
+++ b/ansible/discover-tasks.yml
@@ -39,7 +39,13 @@
      registry: "{{ overrides.registry | default(registry) }}"
 # Prepath is the relative path of the start of the unfetter code directories
      prepath: "{{ overrides.prepath | default(prepath) }}"
-  
+# Variables that control how ansible connects to remote system.  Right now, we only 
+# assume a single remote system.
+# Ansible Host IP if remote.  Right now, we only have a single 
+     ansible_host: "{{ overrides.ansible_host | default(ansible_host) }}"
+     ansible_ssh_private_key_file: "{{ overrides.ansible_ssh_private_key_file | default(ansible_ssh_private_key_file) }}"
+     ansible_connection: "{{ overrides.ansible_connection | default(ansible_connection) }}"
+     ansible_python_interpreter: "{{ overrides.ansible_python_interpreter | default(ansible_python_interpreter) }}"
   #  Displaying the variables.
   - debug:
         msg: 
@@ -51,7 +57,10 @@
           - "use_taxii: {{ use_taxii }}"
           - "registry: {{ registry }}"    
           - "prepath: {{ prepath }}"    
-  
+          - "remote home: {{ ansible_env.HOME }}" 
+          - "ansible_host = {{ ansible_host }}"
+          - "ansible_ssh_private_key_file = {{ ansible_ssh_private_key_file }}"
+          - "ansible_connection = {{ ansible_connection }}"
   - include_role:
         name: common
   - include_role:

--- a/ansible/group_vars/override_vars.yml
+++ b/ansible/group_vars/override_vars.yml
@@ -1,6 +1,5 @@
     # To override any of the variables, just uncomment the line to override
     
-    #tag: "0.3.6"
     #docker_tag: "0.3.6"
     #prepath: "../../"
     #build_action: "pull" 
@@ -10,3 +9,8 @@
     #use_taxii: false
     #run_mode: "dev"
     #registry: "unfetter/"
+    #ansible_ssh_host: "127.0.0.1"
+    #ansible_ssh_private_key_file: "~/.ssh/ansible"
+    #ansible_connection: "ssh"
+    
+    

--- a/ansible/group_vars/override_vars.yml
+++ b/ansible/group_vars/override_vars.yml
@@ -9,7 +9,7 @@
     #use_taxii: false
     #run_mode: "dev"
     #registry: "unfetter/"
-    #ansible_ssh_host: "127.0.0.1"
+    #ansible_host: "127.0.0.1"
     #ansible_ssh_private_key_file: "~/.ssh/ansible"
     #ansible_connection: "ssh"
     

--- a/ansible/hosts.ini
+++ b/ansible/hosts.ini
@@ -12,21 +12,30 @@
 
 [all:vars]
 
+# If local, then use ../../ or the full directory path to the directory above the "unfetter" directory.  
+#prepath = '../../'
+prepath={{ ansible_env.HOME }}/unfetter-discover/
+# This is the default target host.  if the host is local, use 127.0.0.1
+ansible_host = "127.0.0.1"
+# If the host is local, then use "", else enter the location of the SSH key file
+#ansible_ssh_private_key_file = "~/.ssh/ansible"
+ansible_ssh_private_key_file = ""
+# "local" if this is a local build.  Else, "ssh"
+#ansible_connection = "ssh"
+ansible_connection = "local"
+ansible_python_interpreter = "python"
+# If local, then use ../../ or the full directory path to the directory above the "unfetter" directory.  
+prepath = '../../'
+#prepath={{ ansible_env.HOME }}/unfetter-discover/
 latest_production_tag = "0.3.8"
-next_tag = "0.3.8"
+next_tag = "0.3.9"
 beta_version = ".beta.3"
-
 # run_action tells Ansible if the container should be running.  This is always true for this playbook. 
 run_action=true
-
-
 # use_taxii tells Ansible if the Taxii server should be running.  At the moment, this will always be false.
 use_taxii=false
-
 # This is the path, relative to the ansible directory, from which all the other source code directories are.
 #   This is necessary when building the other docker images from Source
-prepath="../../"
-
 # The docker network name
 docker_network_name="unfetter_network"
 
@@ -49,7 +58,7 @@ dev-demo
 [develop:vars]
 # In development, we use local host.  This can be overwritten if we are building to 
 # external systems.  
-ansible_connection=local
+#ansible_connection=local
 ansible_python_interpreter=python
 
 # Docker Tag specifies what will be the name of the developed tag.
@@ -95,7 +104,7 @@ build
 use_uac=true
 auth_services=["github"]
 gitlab_url="https://gitlab.com"
-ui_domain = 'localhost'
+ui_domain = '10.113.67.97'
 
 # Demo mode does not have UAC
 [demo]

--- a/ansible/roles/api/tasks/main.yml
+++ b/ansible/roles/api/tasks/main.yml
@@ -26,7 +26,6 @@
     networks:
       - name: "{{ docker_network_name }}"          
     volumes: "{{ volume_list }}"
-#    links: "{{ api_link_list }} + {{ api_uac_link_list if use_uac == true else '' }}"
 
     env:
       CTF_PARSE_HOST: http://unfetter-ctf-ingest
@@ -50,5 +49,5 @@
       MONGO_DEBUG: "true"
     entrypoint:
       - npm
-      - start
+      - "{{ 'run debugdev' if run_mode == 'dev' else 'start' }}"
   when: run_action     

--- a/ansible/roles/api/vars/main.yml
+++ b/ansible/roles/api/vars/main.yml
@@ -11,12 +11,4 @@ dev_volume_list: ",{{ prepath }}unfetter-store/unfetter-discover-api/test:/usr/s
 uac_volume_list: ",private-config:/usr/share/unfetter-discover-api/api/config/private"
 volume_list: "{{ base_list }}{{ uac_volume_list if use_uac else '' }}{{ dev_volume_list if run_mode == 'dev' else '' }}"
 
-# Base link list
-api_link_list:
-  - "cti-stix-store-repository:cti-stix-store-repository"
-  - "unfetter-pattern-handler:unfetter-pattern-handler"
-
-# Added lists for UAC mode
-api_uac_link_list:
-  - "unfetter-socket-server:socketserver"
 

--- a/ansible/roles/gateway/tasks/main.yml
+++ b/ansible/roles/gateway/tasks/main.yml
@@ -15,8 +15,9 @@
 - name: "Copy the DISTRIBUTION code"
   copy:
     src: "{{ prepath }}/unfetter-ui/dist"
-    dest: "{{ role_path }}/files/"
+    dest: "{{ remote_role_directory }}files/"
     force: true
+    remote_src: yes
   when: "('production' in group_names and build_action=='local')"
     
     
@@ -25,14 +26,15 @@
     name: "{{ container_name }}"
     tag: "{{ docker_tag }}"
     state: present
-    path: "{{ role_path }}/files"
+    path: "{{ remote_role_directory }}files"
   when: "('production' in group_names and build_action=='local')"
 
 - name: "Build new template"
   template: 
     src: '{{ role_path }}/templates/default.j2'
-    dest: '{{ role_path }}/files/conf.d/default.conf'
+    dest: '{{ remote_role_directory }}files/conf.d/default.conf'
     force: true
+  remote_src: true 
 # when: Unsure when to do this, I guess every time this needs to get deployed.    
 
 # Creates the docker container for the gateway
@@ -51,7 +53,7 @@
     - "80:80"
 #    links: "{{ link_list }}"
     volumes: 
-     - "{{ role_path }}/files/conf.d/default.conf:/etc/nginx/conf.d/default.conf"
+     - "{{ remote_role_directory }}/files/conf.d/default.conf:/etc/nginx/conf.d/default.conf"
      - "{{ prepath }}/unfetter/config/nginx/conf.d.extra/:/etc/nginx/conf.d.extra"
 #     - "{{ prepath }}/unfetter/config/certs/:/etc/pki/tls/certs"
      - "certs:/etc/pki/tls/certs:ro"

--- a/ansible/roles/gateway/vars/main.yml
+++ b/ansible/roles/gateway/vars/main.yml
@@ -1,4 +1,4 @@
 ---
 container_name: "unfetter-discover-gateway"
 image_name: "{{registry}}{{ container_name }}:{{docker_tag}}"
-
+remote_role_directory: "{{ prepath }}unfetter/ansible/roles/gateway/"

--- a/ansible/roles/unfetter/tasks/main.yml
+++ b/ansible/roles/unfetter/tasks/main.yml
@@ -1,0 +1,18 @@
+# Ensure the volumes are created. 
+- name: Clone Unfetter Git
+  git:
+     repo: "https://github.com/unfetter-discover/unfetter.git"
+     dest: "{{ prepath }}unfetter"
+     version: "{{ branch }}"
+
+- name: Clone if in Dev
+  git:
+     repo: "https://github.com/unfetter-discover/{{ item }}.git"
+     dest: "{{ prepath }}{{ item }}"
+     version: "{{ branch }}"
+  loop:
+     - unfetter-store
+     - unfetter-ui
+     - stix2pattern
+
+

--- a/ansible/roles/unfetter/vars/main.yml
+++ b/ansible/roles/unfetter/vars/main.yml
@@ -1,0 +1,5 @@
+---
+
+# The VARS for building and preparing the Unfetter HOSTS for docker
+
+branch: "{{ 'develop' if run_mode == 'dev' else 'master'}}"

--- a/ansible/task-backup-vol-container.yml
+++ b/ansible/task-backup-vol-container.yml
@@ -38,9 +38,9 @@
       with_items:
 
         - docker cp unfetter-socket-server:/usr/share/unfetter-socket-server/config/private/private-config.json {{ private_vol }}/private-config.json
-        - docker run -v private-config:/config/private --name helper busybox true
-        - docker cp {{ private_vol }}/private-config.json helper:/config/private
-        - docker rm helper
+#        - docker run -v private-config:/config/private --name helper busybox true
+#        - docker cp {{ private_vol }}/private-config.json helper:/config/private
+#        - docker rm helper
         
         #command: "docker run --rm -it -v private-config:/api/private -v ui-config:/ui/private -v $thepath/files/scripts/api_configuration_tool.py:/scripts/api_configuration_tool.py --name api-config python:2.7.15-alpine3.6 python /scripts/api_configuration_tool.py"
     - name: add to inventory for mongo
@@ -50,7 +50,8 @@
       #changed_when: false
       notify: 
        - backup mongo
-    # Once the mongo-db volume is created, this handler will backup the database and extract it
+      become: yes 
+   # Once the mongo-db volume is created, this handler will backup the database and extract it
     
     # When the database file is archived and extracted, it needs to be moved into the 
     # volume and restored as a valid mongo database
@@ -60,12 +61,8 @@
 
 
     - name: backup mongo
-      delegate_to: cti-stix-store-repository
-      raw: "{{ item }}"
+      command: "{{ item }}"
       with_items:
-        - "mongodump --host localhost --archive=/data/db/mongo.archive"
-        - "cp /data/db/mongo.archive /tmp/"
-      notify:
-      - retrieve mongo-db backup
-    - name: retrieve mongo-db backup
-      command: "docker cp cti-stix-store-repository:/tmp/mongo.archive {{ mongodb_vol }}/mongo.archive"
+        - "docker exec cti-stix-store-repository mongodump --host localhost --archive=/data/db/mongo.archive"
+        - "docker exec cti-stix-store-repository cp /data/db/mongo.archive /tmp/"
+        - "docker cp cti-stix-store-repository:/tmp/mongo.archive {{ mongodb_vol }}/mongo.archive"

--- a/ansible/task-prep-remote-host.yml
+++ b/ansible/task-prep-remote-host.yml
@@ -1,0 +1,24 @@
+---
+####################################################################################
+#  This playbook only builds the docker images locally
+#
+####################################################################################
+
+
+- name: Prepare the Docker Host 
+  hosts: dev 
+#  become: true
+  vars:
+     pip_install_packages:
+       - name: docker
+  tasks:
+
+ # - debug:
+ #     var: result
+
+  roles:
+    - { role: geerlingguy.docker, docker_users: [{{ ansible_user }}], become: true }
+    - { role: geerlingguy.git, become: true }
+    - { role: geerlingguy.pip, become: true }
+    - unfetter  
+ 


### PR DESCRIPTION
A bunch of fixes for the ansible playbooks:

- Supports changing to remote hosts by changing the ansible_host, ansible_connection, prepath and ansible_ssh_private_key variables
- Fixed bug that caused the "task-backup-vol-container.yml" to create the volume prematurely
- Added a task-prep-remote-host.yml playbook that will prepare a remote host

To test remote access, make these changes in the hosts.ini
- assign your remote IP address to the ansible_host variable
- set the ansible_connection to "ssh"
- set the prepath to the remote root directory for all the github projects
- set the ansible_ssh_private_key" to the location and name of the private key.
- Then, run the "task_prep-remote_hosts.yml" file

