### PR TITLE
Push demo versions

### DIFF
--- a/ansible/deploy-dev-demo.yml
+++ b/ansible/deploy-dev-demo.yml
@@ -1,17 +1,15 @@
 ---
 ####################################################################################
-#  This playbook only builds the docker images locally
+#  This playbook only builds in dev mode.  
 #
 ####################################################################################
 
 
-- name: Build the Docker images only.  Do not 
-  hosts: build
+- name: Build Playbook
+  hosts: dev-demo
   tasks:
-  - name: Iterate over group variables
-    debug:
-      var: item
-    with_items: "{{ hostvars | to_nice_json }}"           
+                   
   - name: Start running the commands
     import_tasks: discover-tasks.yml
+
 

--- a/ansible/deploy-prod-demo.yml
+++ b/ansible/deploy-prod-demo.yml
@@ -1,17 +1,15 @@
 ---
 ####################################################################################
-#  This playbook only builds the docker images locally
+#  This playbook only builds in dev mode.  
 #
 ####################################################################################
 
 
-- name: Build the Docker images only.  Do not 
-  hosts: build
+- name: Build Playbook
+  hosts: prod-demo
   tasks:
-  - name: Iterate over group variables
-    debug:
-      var: item
-    with_items: "{{ hostvars | to_nice_json }}"           
+                   
   - name: Start running the commands
     import_tasks: discover-tasks.yml
+
 

--- a/ansible/hosts.ini
+++ b/ansible/hosts.ini
@@ -53,9 +53,8 @@ backup_directory="{{ playbook_dir }}/backup"
 # The Develop group specifies that the code must be built from local directories
 
 [develop]
-dev
 dev-demo
-
+dev
 
 [develop:vars]
 # In development, we use local host.  This can be overwritten if we are building to 
@@ -92,8 +91,8 @@ use_unfetter_ui=false
 
 # Run Mode states if we are building in production vs demo, telling containers if they need UAC or not
 run_mode="prod"
-#registry="unfetter/"
-registry=""
+registry="unfetter/"
+#registry=""
 
 
 # UAC group says that UAC for github/gitlab will be turned on.

--- a/ansible/roles/gateway/files/conf.d/default.conf
+++ b/ansible/roles/gateway/files/conf.d/default.conf
@@ -34,9 +34,8 @@ server {
     proxy_pass https://unfetter-socket-server:3333/socket/;
   }
   
-  
-  location / {
-    proxy_pass https://unfetter-ui:80;
+    location / {
+    try_files $uri$args $uri$args/ /index.html;
   }
   
 }

--- a/ansible/roles/gateway/tasks/main.yml
+++ b/ansible/roles/gateway/tasks/main.yml
@@ -12,13 +12,13 @@
 
   # Building the image if build_action is local
 
-- name: "Copy the DISTRIBUTION code"
-  copy:
-    src: "{{ prepath }}/unfetter-ui/dist"
-    dest: "{{ remote_role_directory }}files/"
-    force: true
-    remote_src: yes
-  when: "('production' in group_names and build_action=='local')"
+#- name: "Copy the DISTRIBUTION code"
+#  copy:
+#    src: "{{ prepath }}unfetter-ui/dist"
+#    dest: "{{ remote_role_directory }}files/"
+#    force: true
+#    remote_src: {{ if ansible_host == 'local' 'no' else 'yes' }}
+#  when: "('production' in group_names and build_action=='local')"
     
     
 - name: "Build {{ container_name }} from Gateway Dockerfile"


### PR DESCRIPTION
Provided two different playbooks.
- deploy-prod-demo.yml
- deploy-dev-demo.yml

These playbooks will build and deploy Unfetter in demo mode for dev and production builds.