### PR TITLE
added handling for attachments for nginx to ansible

### DIFF
--- a/ansible/hosts.ini
+++ b/ansible/hosts.ini
@@ -45,6 +45,11 @@ docker_network_name="unfetter_network"
 use_taxii_tls=false
 
 backup_directory="{{ playbook_dir }}/backup"
+
+# Parameter pasted to nginx's `client_max_body_size` variable for attachments being uploaded to the API
+# 0 means there is no size limit
+attachments_max_size=0
+
 # Ansible allows hosts to belong to groups, and those groups
 # can have different variables.  A host can belong to multiple groups.
 # We use this to specify if the build will be in demo or uac mode, if 

--- a/ansible/roles/gateway/templates/default.j2
+++ b/ansible/roles/gateway/templates/default.j2
@@ -18,6 +18,7 @@ server {
   }
   
   location /api/ {
+    client_max_body_size {{ attachments_max_size }};
     proxy_pass https://unfetter-discover-api:3000/;
   }
 


### PR DESCRIPTION
Restart the stack with ansible, go to analytic exchange and upload a file between 20MB and 500MB in size, and confirm the upload and download works correctly.