### PR TITLE
updated socket server references

### DIFF
--- a/ansible/roles/api/tasks/main.yml
+++ b/ansible/roles/api/tasks/main.yml
@@ -43,7 +43,7 @@
       HTTPS_PROXY_URL: ""
       PATTERN_HANDLER_DOMAIN: unfetter-pattern-handler
       PATTERN_HANDLER_PORT: 5000
-      SOCKET_SERVER_DOMAIN: "{{ 'socketserver' if use_uac else '' }}"
+      SOCKET_SERVER_DOMAIN: "{{ 'unfetter-socket-server' if use_uac else '' }}"
       SOCKET_SERVER_PORT: "{{ '3333' if use_uac else '' }}"
       #MONGO_DEBUG: "{{ 'false' if use_uac else '' }}"
       MONGO_DEBUG: "true"

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -73,7 +73,7 @@ services:
     - unfetter-discover-openssl
     - cti-stix-store-repository
     links:
-     - unfetter-socket-server:socketserver
+     - unfetter-socket-server:unfetter-socket-server
     volumes:
     - ./certs/:/etc/pki/tls/certs
     - ../unfetter-store/unfetter-discover-api/test:/usr/share/unfetter-discover-api/test

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -88,7 +88,7 @@ services:
     depends_on:
     - unfetter-socket-server
     links:
-    - unfetter-socket-server:socketserver
+    - unfetter-socket-server:unfetter-socket-server
     ports:
     - "49360:3000"
     - "5555:5555"
@@ -98,7 +98,7 @@ services:
     - ../unfetter-store/unfetter-discover-api/app.js:/usr/share/unfetter-discover-api/app.js
     - ../unfetter-store/unfetter-discover-api/config/private:/usr/share/unfetter-discover-api/config/private
     environment:
-    - SOCKET_SERVER_DOMAIN = socketserver
+    - SOCKET_SERVER_DOMAIN = unfetter-socket-server
     - SOCKET_SERVER_PORT = 3333
     - ENV=dev
     # Options: UAC, TEST, DEMO


### PR DESCRIPTION
Requires `issue-1336` on `unfetter` and `unfetter-store`

Associated PR: https://github.com/unfetter-discover/unfetter-store/pull/239

Instructions:
- Restart stack
- Do an action to create a notification (eg, post a stix in Unfetter of NSA with a 2nd account)
- Confirm notification occurred (either by checking on the other account or looking at `docker logs unfetter-socket-server`)
 - I also attempted to fix attachments and comment avatars in this PR: Try attachments and commenting in AE

fixes #1336 