### PR TITLE
changed socket server entrypoint handling

### DIFF
--- a/ansible/roles/socket-server/tasks/main.yml
+++ b/ansible/roles/socket-server/tasks/main.yml
@@ -27,7 +27,7 @@
     entrypoint:
      - npm
      - run
-     - start:deploy
+     - "{{ 'start' if run_mode == 'dev' else 'start:deploy' }}"
     env:
       MONGO_REPOSITORY: cti-stix-store-repository
       MONGO_PORT: 27017


### PR DESCRIPTION
Requires two github account and `issue-1343` on `unfetter` and `unfetter-store`

Assoc. PR https://github.com/unfetter-discover/unfetter-store/pull/243

Goal: To ensure sockets are removed from the socket server on disconnect

Instructions
- `docker logs unfetter-socket-server -f`
- On user 1, open Unfetter in multiple tabs/windows
- On user 2, add an analytic in a group (other than open) both users are in, and confirm there is a log for each user 1 instance
- Close the tabs/windows for all but 1 instance for user 1
- On user 2, add an analytic in a group (other than open) both users are in, and confirm there is only 1 log message (ie, that the other ones were properly removed)

fixes #1343