### PR TITLE
Issue 1373/no cat

### DIFF
--- a/ansible/roles/common/files/migrate/0.3.10-user-model.js
+++ b/ansible/roles/common/files/migrate/0.3.10-user-model.js
@@ -1,0 +1,122 @@
+/*
+ * Before you run this command, be sure the Mongo container is up and running.
+ * 
+ * The purpose of this script is to update a pre-0.3.10 Unfetter database to 0.3.10.
+ */
+
+const mongoose = require('mongoose');
+const argv = require('./cli.service').argv;
+
+/**
+ * Required schemas for this update.
+ */
+const CapabilitySchema = mongoose.Schema({
+    stix: {
+        id: String,
+        name: {
+            type: String,
+            required: [true, 'name is required'],
+            index: true
+        },
+        category: String
+    },
+});
+
+
+/*
+ * The purpose of this function is to correct the omission of the category attribute in the Autologon capability
+ * within the DoDCAR sample assessments data.
+ */
+function updateCapabilities(capCorrection) {
+    console.log('Starting sample capability correction');
+    const Capabilities = mongoose.connection.model('Stix', CapabilitySchema, capCorrection.collection);
+    return new Promise((resolve, reject) => {
+        Capabilities.find(capCorrection.search, (err, capabilities) => {
+            if (capCorrection.testFailure === true) {
+                reject('Deliberate test failure');
+            } else if (err) {
+                reject(`Error retrieving capabilities data: ${err}`);
+            } else {
+                console.log('All capabilities: ' + capabilities);
+                Promise
+                    .all(
+                        capabilities.map(capability => new Promise((res, rej) => updateCapability(Capabilities, capability, res, rej)))
+                    )
+                    .then(
+                        result => resolve({ migration: capCorrection.name, success: true, detail: result }),
+                        error => reject({ migration: capCorrection.name, success: false, detail: error })
+                    )
+                    .catch(error => reject({ migration: capCorrection.name, success: false, detail: error }))
+                    .finally(() => console.log('Corrections to sample capabilities complete.'));
+            }
+        });
+    });
+}
+
+async function updateCapability(Capabilities, capability, resolve, reject) {
+    await Capabilities.update(
+        { 'stix.id': capability.stix.id },
+        {
+            $set: { 'stix.category': 'x-unfetter-category--77815162-52a2-4ce6-b5ad-b88105b6f63d' },
+        }
+    );
+    resolve({ capability: capability.name });
+}
+
+const MIGRATIONS = [
+    {
+        name: 'MissingCategories',
+        collection: 'stix',
+        search: { 'stix.id' : 'x-unfetter-capability--46d585a6-7480-415c-b29b-5c719934f519' },
+        migrator: updateCapabilities,
+        testFailure: false
+    },
+];
+
+(() => {
+
+    // The maximum amount of tries mongo will attempt to connect
+    const MAX_NUM_CONNECT_ATTEMPTS = argv.attempts;
+
+    // The amount of time between each connection attempt in ms
+    const CONNECTION_RETRY_TIME = argv.interval * 1000;
+
+    let connInterval;
+    let connAttempts = 0;
+
+    // Wait for mongoose to connect before processing
+    mongoose.connection.on('connected', () => {
+        console.log('Connected to mongodb...');
+        mongoose.set('debug', true);
+        clearInterval(connInterval);
+        let returnCode = 0;
+        Promise.all(MIGRATIONS.map(migration => migration.migrator(migration)))
+            .then(
+                result => { console.debug('fulfilled', result); },
+                error => { console.error('failed', error); }
+            )
+            .catch(error => {
+                console.error(error);
+                returnCode = 1;
+            })
+            .finally(() => {
+                mongoose.connection.close(() => console.log('Mongoose connection closed.'));
+                process.exit(returnCode);
+            });
+    });
+
+    mongoose.connection.on('error', (err) => {
+        console.log(`Mongoose connection error: ${err}`);
+        if (connAttempts >= MAX_NUM_CONNECT_ATTEMPTS) {
+            clearInterval(connInterval);
+            console.log('Maximum number of connection attempts exceeded. Terminating program.');
+            process.exit(1);
+        }
+    });
+
+    connInterval = setInterval(() => {
+        connAttempts += 1;
+        mongoose.connect(`mongodb://${argv.host}:${argv.port}/${argv.database}`, { useMongoClient: true });
+    }, CONNECTION_RETRY_TIME);
+
+})();

--- a/ansible/roles/common/tasks/migrate-0.3.10.yml
+++ b/ansible/roles/common/tasks/migrate-0.3.10.yml
@@ -1,0 +1,46 @@
+
+####################################################################################
+#  This playbook migrates from 0.3.9 to 0.3.10
+#
+#
+####################################################################################
+
+- name: Create Repository
+  docker_container:
+    name: cti-stix-store-repository
+    image: "mongo:3.4.1"
+    state: started
+    networks:
+      - name: "{{ docker_network_name }}"          
+    # Since the repository is a mongodb, we always pull
+    pull: true
+    volumes:
+#    - "{{ prepath }}/unfetter/data/db:/data/db"
+    - "mongo-db:/data/db"
+    published_ports:
+    - "27018:27017"
+  when: run_action 
+- debug:
+    msg: "role is :{{ remote_role_directory }}"
+
+- name: "Build Docker Image"
+  docker_image:
+    name: migration
+    tag: "{{ docker_tag }}"
+    state: present
+    force: true
+    path: "{{ remote_role_directory }}files/migrate"
+
+- name: "Run container"
+  docker_container:
+    name: "migration"
+    image: "migration:{{ docker_tag }}"
+    state: started
+    networks:
+      - name: "{{ docker_network_name }}"
+    # Since the repository is a mongodb, we always pull
+    #volumes:
+    #  - "{{ remote_role_directory }}/files/migrate:/usr/src/app/migrate"
+    entrypoint:
+      - node
+      - /usr/share/app/0.3.10-user-model.js -h cti-stix-store-repository -p 27017 -d stix

--- a/ansible/task-upgrade-0.3.10.yml
+++ b/ansible/task-upgrade-0.3.10.yml
@@ -1,12 +1,12 @@
 ---
 ####################################################################################
-#  This playbook will upgrade from 0.3.6 to 0.3.9  
+#  This playbook will upgrade from 0.3.9 to 0.3.10  
 #
 ####################################################################################
 
-- name: Upgrades Unfetter to support version 0.3.9
+- name: Upgrades Unfetter to support version 0.3.10
   hosts: dev
   tasks:
     - include_role:
           name: common
-          tasks_from: migrate-0.3.9.yml
+          tasks_from: migrate-0.3.10.yml

--- a/config/examples/unfetter-stix/assessments3/capabilities.stix.json
+++ b/config/examples/unfetter-stix/assessments3/capabilities.stix.json
@@ -312,6 +312,7 @@
       "created": "2018-03-23T18:43:23.711Z",
       "name": "Autologon",
       "description": "Autologon enables you to easily configure Windows’ built-in autologon mechanism. Instead of waiting for a user to enter their name and password, Windows uses the credentials you enter with Autologon, which are encrypted in the Registry, to log on the specified user automatically.",
+      "category": "x-unfetter-category--77815162-52a2-4ce6-b5ad-b88105b6f63d",
       "external_references": [
         {
           "source_name": "Microsoft",


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1373

This adds a `category` attribute to one of the sample capabilities for baselines.  The attribute is added as part of a new migration script for 0.3.10.

### To test:
1. Pull this branch
2. In Robo 3T, connect to the stix DB, and run this query:  `db.getCollection('stix').find({"stix.id": 'x-unfetter-capability--46d585a6-7480-415c-b29b-5c719934f519'})`
(You'll notice there is no `category` attribute)
3. Stop and remove all containers
4. Run the migration task:  `ansible-playbook task-upgrade-0.3.10.yml'
5. Verify all is `ok`:  
`PLAY RECAP **********************************************************************
dev                        : ok=34   changed=10   unreachable=0    failed=0 `
6. Refresh and re-run the query in Robo 3T and there should be a `category` attribute now pointing to the `Autoruns` category.  You can verify this by running this query:  `db.getCollection('stix').find({"stix.id": 'x-unfetter-category--77815162-52a2-4ce6-b5ad-b88105b6f63d'})`