### PR TITLE
Squash images when building production

### DIFF
--- a/ansible/roles/api/tasks/main.yml
+++ b/ansible/roles/api/tasks/main.yml
@@ -47,6 +47,7 @@
       SOCKET_SERVER_PORT: "{{ '3333' if use_uac else '' }}"
       #MONGO_DEBUG: "{{ 'false' if use_uac else '' }}"
       MONGO_DEBUG: "true"
+    working_dir:  "/usr/share/unfetter-discover-api/"      
     entrypoint:
       - npm
       - run

--- a/ansible/roles/common/tasks/migrate-0.3.7.yml
+++ b/ansible/roles/common/tasks/migrate-0.3.7.yml
@@ -1,0 +1,14 @@
+
+####################################################################################
+#  This playbook migrates from 0.3.8 to 0.3.9
+#
+#
+####################################################################################
+
+
+- name: Dropping Indexes
+  command: "{{ item }}"
+  with_items:
+    - "docker exec cti-stix-store-repository mongo stix --eval \"db.getCollection('stix').dropIndexes()\""
+    - "docker exec cti-stix-store-repository mongo stix --eval \"db.getCollection('user').dropIndexes()\""
+

--- a/ansible/roles/common/tasks/restart-container.yml
+++ b/ansible/roles/common/tasks/restart-container.yml
@@ -1,0 +1,7 @@
+# Used to restart the container
+
+
+- name: Restart Repository
+  docker_container:
+    name: cti-stix-store-repository
+    restart: true

--- a/ansible/roles/explorer/tasks/main.yml
+++ b/ansible/roles/explorer/tasks/main.yml
@@ -26,7 +26,7 @@
     image: "{{ image_name }}"
     networks:
       - name: "{{ docker_network_name }}"          
-   
+    working_dir: /usr/share/unfetter-api-explorer
     state: started
     env: 
      PUBLIC_PATH: /explorer/

--- a/ansible/roles/ingest/tasks/main.yml
+++ b/ansible/roles/ingest/tasks/main.yml
@@ -28,6 +28,7 @@
     entrypoint:
       - npm
       - start
+    working_dir: /usr/share/unfetter-ctf-ingest
     env:
       API_PROTOCOL: https
       API_HOST: unfetter-discover-api

--- a/ansible/roles/pattern-handler/tasks/main.yml
+++ b/ansible/roles/pattern-handler/tasks/main.yml
@@ -21,6 +21,7 @@
     name: "{{ container_name }}"
     image: "{{ image_name }}"
     state: started
+    working_dir: /opt/stix/
     networks:
       - name: "{{ docker_network_name }}"          
     exposed_ports: 

--- a/ansible/roles/processor/tasks/main.yml
+++ b/ansible/roles/processor/tasks/main.yml
@@ -26,6 +26,7 @@
     networks:
       - name: "{{ docker_network_name }}"           
     volumes: "{{ volume_list }}"
+    working_dir: /usr/src/app
     env:
      PATTERN_HANDLER_DOMAIN: unfetter-pattern-handler
      PATTERN_HANDLER_PORT: 5000    
@@ -33,6 +34,7 @@
      # If deployed in a proxy, add the proxy's URL here
      HTTPS_PROXY_URL: ''
     entrypoint:
+    
      - ts-node
      - src/app.ts
      - --stix

--- a/ansible/roles/socket-server/tasks/main.yml
+++ b/ansible/roles/socket-server/tasks/main.yml
@@ -28,6 +28,7 @@
      - npm
      - run
      - "{{ 'start' if run_mode == 'dev' else 'start:deploy' }}"
+    working_dir: /usr/share/unfetter-socket-server
     env:
       MONGO_REPOSITORY: cti-stix-store-repository
       MONGO_PORT: 27017

--- a/ansible/roles/ui/tasks/main.yml
+++ b/ansible/roles/ui/tasks/main.yml
@@ -33,6 +33,7 @@
       name: "{{ container_name }}"
       image: "{{ image_name }}"
       state: started
+      working_dir: /usr/share/unfetter-ui
       networks:
       - name: "{{ docker_network_name }}"      
       entrypoint:
@@ -44,5 +45,3 @@
         - "{{ prepath }}/unfetter-ui/src:/usr/share/unfetter-ui/src"
         - "ui-config:/usr/share/unfetter-ui/src/assets/config"
   when: "(use_unfetter_ui) and (run_action)"
-
-#docker run --rm -v /Users/alchemist/workspace/alchemist/unfetter-discover/unfetter/ansible/roles/ui/files/dist:/usr/share/unfetter-ui/dist --name unfetter-ui-build-temp unfetter-ui:0.3.8 run build:prod:noclean:ff31

--- a/ansible/task-push-registry.yml
+++ b/ansible/task-push-registry.yml
@@ -10,8 +10,7 @@
 #  become: true
   vars:
     registry: "unfetter/"
-#     next_tag: "0.3.9"
-#     beta_version: ".beta.3"
+    #docker_tag: "0.3.9"
     image_list:
          - "unfetter-api-explorer"
          - "unfetter-discover-processor"
@@ -19,35 +18,76 @@
          - "unfetter-ui"
          - "unfetter-ctf-ingest"
          - "unfetter-pattern-handler"
+         - "unfetter-socket-server"
 
     gateway_config:
          - "uac"
          - "legacy.uac"
          - "legacy.demo"
          - "demo"
+    latest: false
   tasks:
-
- # - debug:
-    - name: Tagging with Latest
-      command: "docker tag {{ item }}:{{ docker_tag }} {{ registry }}{{ item }}:latest"
+    - name: Build running containers for every image besides gateway
+      docker_container:
+        name: "{{ item }}.ready-to-export"
+        image: "{{ item }}:{{ docker_tag }}"
+        state: started
+        entrypoint:
+           - ls /tmp
       with_items: "{{ image_list }}"
+      
+    - name: Build running containers for every gateway
+      docker_container:
+        name: "unfetter-discover-gateway.{{ item }}.ready-to-export"
+        image: "unfetter-discover-gateway:{{ docker_tag }}.{{ item }}"
+        state: started
+        entrypoint:
+           - ls /tmp
+      with_items: "{{ gateway_config }}"  
+
+    - name: Exporting the Images to tar
+      command: "docker export -o {{ item }}.ready-to-export.tar {{ item }}.ready-to-export"
+      with_items: "{{ image_list }}"
+
+
+    - name: Exporting the Gateway Images to tar
+      command: "docker export -o unfetter-discover-gateway.{{ item }}.ready-to-export.tar unfetter-discover-gateway.{{ item }}.ready-to-export"
+      with_items: "{{ gateway_config }}"
+
+
+    - name: Import the Images
+      command: docker import {{ item }}.ready-to-export.tar  {{ item }}:{{ docker_tag }}
+      with_items: "{{ image_list }}"
+
+    - name: Import the Gateway Images
+      command: docker import unfetter-discover-gateway.{{ item }}.ready-to-export.tar  unfetter-discover-gateway:{{ docker_tag }}.{{ item }}
+      with_items: "{{ gateway_config }}"
+
+
+    - name: Tagging with Latest
+      command: "docker tag {{ item }}:{{ docker_tag }}.squashed {{ registry }}{{ item }}:latest"
+      with_items: "{{ image_list }}"
+      when: latest
+
     - name: Tagging gateway with latest
       command: "docker tag unfetter-discover-gateway:{{ docker_tag }}.demo {{ registry }}unfetter-discover-gateway:latest"
-
+      when: latest
+  
     - name: Tagging with {{ next_tag }}
-      command: "docker tag {{ item }}:{{ docker_tag }} {{ registry }}{{ item }}:{{ next_tag }}"
+      command: "docker tag {{ item }}:{{ docker_tag }} {{ registry }}{{ item }}:{{ docker_tag }}"
       with_items: "{{ image_list }}"       
 
     - name: Tagging Gateway with {{ next_tag }}
-      command: "docker tag unfetter-discover-gateway:{{ docker_tag }}.{{ item }} {{ registry }}unfetter-discover-gateway:{{ next_tag }}.{{ item }}"
+      command: "docker tag unfetter-discover-gateway:{{ docker_tag }}.{{ item }} {{ registry }}unfetter-discover-gateway:{{ docker_tag }}.{{ item }}"
       with_items: "{{ gateway_config }}"
 
 
     - name: Pushing to {{ registry }}
-      command: "docker push {{ registry }}{{ item }}:{{ next_tag }}"
-      with_items: "{{ image_list }}"        
+      command: "docker push {{ registry }}{{ item }}:{{ docker_tag }}"
+      with_items: "{{ image_list }}"
+
     - name: Pushin Gateway with {{ registry }}
-      command: "docker push {{ registry }}unfetter-discover-gateway:{{ next_tag }}.{{ item }}"
+      command: "docker push {{ registry }}unfetter-discover-gateway:{{ docker_tag }}.{{ item }}"
       with_items: "{{ gateway_config }}"
 
  

--- a/ansible/task-upgrade-0.3.7.yml
+++ b/ansible/task-upgrade-0.3.7.yml
@@ -1,0 +1,15 @@
+---
+####################################################################################
+#  This playbook will upgrade from 0.3.6 to 0.3.7
+#
+####################################################################################
+- name: Upgrades Unfetter to support version 0.3.7
+  hosts: all
+  tasks:
+    - include_role:
+          name: common
+          tasks_from: migrate-0.3.7.yml
+    - include_role:
+          name: common
+          tasks_from: restart-container.yml
+


### PR DESCRIPTION
When building the production images, it will create a temp container, save the container to a file, then import the container into a new image.

this removes all the docker layers