### PR TITLE
If in production mode, will map the var to the gateway

### DIFF
--- a/ansible/roles/gateway/files/conf.d.extra/dn-forbidden.conf
+++ b/ansible/roles/gateway/files/conf.d.extra/dn-forbidden.conf
@@ -1,0 +1,3 @@
+if ($forbidden) {
+    return 403;
+}

--- a/ansible/roles/gateway/files/conf.d.extra/dn-map.conf
+++ b/ansible/roles/gateway/files/conf.d.extra/dn-map.conf
@@ -1,0 +1,7 @@
+map_hash_max_size 262144;
+map_hash_bucket_size 262144;
+
+map $ssl_client_s_dn $forbidden {
+        default 1;
+        include ./conf.d.extra/whitelist.conf;
+}

--- a/ansible/roles/gateway/files/conf.d.extra/gzip.conf
+++ b/ansible/roles/gateway/files/conf.d.extra/gzip.conf
@@ -1,0 +1,5 @@
+gzip on;
+gzip_min_length 1100;
+gzip_buffers 4 32k;
+gzip_types application/javascript application/json application/x-javascript text/xml text/css text/plain image/svg image/svg+xml application/x-font-ttf application/vnd.api+json
+gzip_vary on;

--- a/ansible/roles/gateway/files/conf.d.extra/security-headers.conf
+++ b/ansible/roles/gateway/files/conf.d.extra/security-headers.conf
@@ -1,0 +1,4 @@
+add_header X-Frame-Options SAMEORIGIN;
+add_header X-Content-Type-Options nosniff;
+add_header X-XSS-Protection "1; mode=block";
+add_header Strict-Transport-Security max-age=31536000;

--- a/ansible/roles/gateway/files/conf.d.extra/ssl-client.conf
+++ b/ansible/roles/gateway/files/conf.d.extra/ssl-client.conf
@@ -1,0 +1,7 @@
+
+ssl_verify_client on;
+ssl_verify_depth 1;
+ssl_client_certificate /etc/pki/tls/certs/trusted.pem;
+
+add_header X-CLIENT-S-DN $ssl_client_s_dn;
+

--- a/ansible/roles/gateway/files/conf.d.extra/ssl-server.conf
+++ b/ansible/roles/gateway/files/conf.d.extra/ssl-server.conf
@@ -1,0 +1,16 @@
+server_name localhost 0.0.0.0;
+listen 443 ssl http2;
+
+ssl_protocols TLSv1.2;
+ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
+
+ssl_prefer_server_ciphers on;
+ssl_session_timeout 5m;
+ssl_session_cache shared:SSL:50m;
+ssl_session_tickets off;
+
+ssl_certificate /etc/pki/tls/certs/server.crt;
+ssl_certificate_key /etc/pki/tls/certs/server.key;
+
+proxy_set_header X-Forwarded-Host $http_host;
+proxy_set_header X-Forwarded-Proto $scheme;

--- a/ansible/roles/gateway/files/conf.d.extra/whitelist.conf
+++ b/ansible/roles/gateway/files/conf.d.extra/whitelist.conf
@@ -1,0 +1,1 @@
+"CN=mushinlogit,OU=development,O=unfetter,L=san francesco,ST=ca,C=us" 0;

--- a/ansible/roles/gateway/tasks/main.yml
+++ b/ansible/roles/gateway/tasks/main.yml
@@ -32,10 +32,12 @@
 - name: "Build new template"
   template: 
     src: '{{ role_path }}/templates/default.j2'
-    dest: '{{ remote_role_directory }}files/conf.d/default.conf'
+    dest: '{{ role_path }}/files/conf.d/default.conf'
     force: true
   remote_src: true 
-# when: Unsure when to do this, I guess every time this needs to get deployed.    
+
+- debug:
+      msg: The volume is {{ volume_list }}
 
 # Creates the docker container for the gateway
 - name: Create the {{ container_name }} from image {{ image_name }}
@@ -52,11 +54,11 @@
     - "443:443"
     - "80:80"
 #    links: "{{ link_list }}"
-    volumes: 
-     - "{{ remote_role_directory }}/files/conf.d/default.conf:/etc/nginx/conf.d/default.conf"
-     - "{{ prepath }}/unfetter/config/nginx/conf.d.extra/:/etc/nginx/conf.d.extra"
+    volumes: "{{ volume_list }}"
+     #- "{{ remote_role_directory }}/files/conf.d/default.conf:/etc/nginx/conf.d/default.conf"
+     #- "{{ prepath }}/unfetter/config/nginx/conf.d.extra/:/etc/nginx/conf.d.extra"
 #     - "{{ prepath }}/unfetter/config/certs/:/etc/pki/tls/certs"
-     - "certs:/etc/pki/tls/certs:ro"
+     #- "certs:/etc/pki/tls/certs:ro"
   # TAXII
   #   - "{{ prepath }}/unfetter/config/nginx/{{ 'taxii.conf' if use_taxii else 'taxii-blank.conf' }}:/etc/nginx/conf.d.runmode/taxii.conf"
   #   - "{{ prepath }}/unfetter/config/nginx/{{ 'taxii-auth.conf' if use_taxii and use_taxii_tls else 'taxii-auth-blank.conf' }}:/etc/nginx/conf.d.runmode/taxii-auth.conf"
@@ -65,5 +67,7 @@
    # In USE_UNFETTER_UI
   #   - "{{ prepath }}/unfetter/config/nginx/{{ 'ui-dev.conf' if use_unfetter_ui else 'ui-prod.conf' }}:/etc/nginx/conf.d.runmode/ui.conf"
   when: run_action
+#  notify:
+#    - start gateway
 
   

--- a/ansible/roles/gateway/vars/main.yml
+++ b/ansible/roles/gateway/vars/main.yml
@@ -2,3 +2,6 @@
 container_name: "unfetter-discover-gateway"
 image_name: "{{registry}}{{ container_name }}:{{ gateway_tag }}"
 remote_role_directory: "{{ prepath }}unfetter/ansible/roles/gateway/"
+prod_volume_list: ",ui-config:/nginx/html/asset/config"
+base_list: "{{ role_path }}/files/conf.d/default.conf:/etc/nginx/conf.d/default.conf,{{ role_path }}/files/conf.d.extra/:/etc/nginx/conf.d.extra/,certs:/etc/pki/tls/certs"
+volume_list: "{{ base_list }}{{ prod_volume_list if ((not use_unfetter_ui) and (use_uac)) else ''}}"


### PR DESCRIPTION
The gateway was not mapping to the ui-config volume in production mode.

To test, change backup/ui-vol/local-settings.json authentication location to gitlab rather than github

Stop and remove all containers
docker volume rm ui-config
Run ansible playbook deploy-prod-uac.

Go to Unfetter, it should attempt to connect to gitlab when logging in.

*NOTE:   If no ui-config volume is mapped, then the UI defaults to github.  Thats why we have to specify the gitlab, to show that its mapped and found.


