### PR TITLE
fixed various problems with going from 0.3.6 to 0.3.10.yml

### DIFF
--- a/ansible/roles/common/tasks/migrate-0.3.10.yml
+++ b/ansible/roles/common/tasks/migrate-0.3.10.yml
@@ -5,31 +5,14 @@
 #
 ####################################################################################
 
-- name: Create Repository
-  docker_container:
-    name: cti-stix-store-repository
-    image: "mongo:3.4.1"
-    state: started
-    networks:
-      - name: "{{ docker_network_name }}"          
-    # Since the repository is a mongodb, we always pull
-    pull: true
-    volumes:
-#    - "{{ prepath }}/unfetter/data/db:/data/db"
-    - "mongo-db:/data/db"
-    published_ports:
-    - "27018:27017"
-  when: run_action 
-- debug:
-    msg: "role is :{{ remote_role_directory }}"
-
-- name: "Build Docker Image"
+- name: Build Migration Image
   docker_image:
     name: migration
     tag: "{{ docker_tag }}"
     state: present
     force: true
     path: "{{ remote_role_directory }}files/migrate"
+
 
 - name: "Run container"
   docker_container:
@@ -38,9 +21,10 @@
     state: started
     networks:
       - name: "{{ docker_network_name }}"
-    # Since the repository is a mongodb, we always pull
-    #volumes:
-    #  - "{{ remote_role_directory }}/files/migrate:/usr/src/app/migrate"
-    entrypoint:
-      - node
-      - /usr/share/app/0.3.10-user-model.js -h cti-stix-store-repository -p 27017 -d stix
+    links:
+      - cti-stix-store-repository    
+    working_dir: /usr/src/app/
+    cleanup: yes
+    restart: yes
+    command:
+      - 'node /usr/share/app/0.3.10-user-model.js -h cti-stix-store-repository -p 27017 -d stix'

--- a/ansible/roles/common/tasks/migrate-0.3.9.yml
+++ b/ansible/roles/common/tasks/migrate-0.3.9.yml
@@ -5,25 +5,7 @@
 #
 ####################################################################################
 
-- name: Create Repository
-  docker_container:
-    name: cti-stix-store-repository
-    image: "mongo:3.4.1"
-    state: started
-    networks:
-      - name: "{{ docker_network_name }}"          
-    # Since the repository is a mongodb, we always pull
-    pull: true
-    volumes:
-#    - "{{ prepath }}/unfetter/data/db:/data/db"
-    - "mongo-db:/data/db"
-    published_ports:
-    - "27018:27017"
-  when: run_action 
-- debug:
-    msg: "role is :{{ remote_role_directory }}"
-
-- name: "Build Docker Image"
+- name: Build Migration Image
   docker_image:
     name: migration
     tag: "{{ docker_tag }}"
@@ -31,16 +13,18 @@
     force: true
     path: "{{ remote_role_directory }}files/migrate"
 
+
 - name: "Run container"
   docker_container:
     name: "migration"
     image: "migration:{{ docker_tag }}"
     state: started
+    links:
+      - cti-stix-store-repository    
     networks:
       - name: "{{ docker_network_name }}"
-    # Since the repository is a mongodb, we always pull
-    #volumes:
-    #  - "{{ remote_role_directory }}/files/migrate:/usr/src/app/migrate"
-    entrypoint:
-      - node
-      - /usr/share/app/0.3.9-user-model.js -h cti-stix-store-repository -p 27017 -d stix
+    working_dir: /usr/src/app/
+    cleanup: yes
+    restart: yes
+    command:
+      - 'node /usr/share/app/0.3.9-user-model.js -h cti-stix-store-repository -p 27017 -d stix'

--- a/ansible/roles/gateway/tasks/main.yml
+++ b/ansible/roles/gateway/tasks/main.yml
@@ -29,6 +29,9 @@
     path: "{{ remote_role_directory }}files"
   when: "('production' in group_names and build_action=='local')"
 
+- name: make sure dirs are there
+  file: path={{ role_path }}/files/conf.d/ state=directory
+
 - name: "Build new template"
   template: 
     src: '{{ role_path }}/templates/default.j2'

--- a/ansible/task-backup-vol-container.yml
+++ b/ansible/task-backup-vol-container.yml
@@ -40,6 +40,7 @@
       with_items:
         - docker cp unfetter-discover-gateway:/etc/nginx/html/assets/config/local-settings.json {{ ui_vol }}/local-settings.json
       when: ((not use_unfetter_ui) and (use_uac))
+      ignore_errors: yes
 
     # Removing this for now, since we just need to rerun the configuration code again
     # Once the private-config volume is created, this handler will pull the config data from unfetter-discover-api and store
@@ -55,6 +56,9 @@
         
         #command: "docker run --rm -it -v private-config:/api/private -v ui-config:/ui/private -v $thepath/files/scripts/api_configuration_tool.py:/scripts/api_configuration_tool.py --name api-config python:2.7.15-alpine3.6 python /scripts/api_configuration_tool.py"
       when: use_uac
+      ignore_errors: yes
+
+      
     - name: add to inventory for mongo
       add_host:
         name: cti-stix-store-repository


### PR DESCRIPTION
Upgrading from 0.3.6 to 0.3.10. 

TO TEST:
- Backup your EC2
- Ensure that we have a valid installation of 0.3.6 production (uac) version of Unfetter
- Edit "hosts.ini" to ensure that the right version of the deployment is in the deployed group
- Run ansible-playbook task-backup-vol-container.yml
- - You will see errors for local-settings.json from gateway.  That is because the file location has changed.  We have to overwrite it anyways
- - If you have a file in backup/private-vol called private-config.json, rename it to "private-config.json.hold"
- Validate you have a backup/mongo-vol/mongo.archive file.  if not, you will need to run backup again.  
- Now, stop and delete all your docker containers and images.
- - docker stop $(docker ps -a -q)
- - docker rm $(docker ps -a q)
- - docker rmi $(docker images -a)
- - docker volume prune
- run ansible-playbook deploy.yml
- Run the task-upgrade in order