### PR TITLE
Adds blockAttachments to the private-config and custom data to private config

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -23,4 +23,4 @@ legacy: false
 
 
 #  Turn to "true" if you would like to block attachments
-blockAttachments: false 
+block_attachments: false 

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -20,3 +20,7 @@ attachments_max_size: 0
 ansible_python_interpreter: python
 latest_production_tag: 0.3.9
 legacy: false
+
+
+#  Turn to "true" if you would like to block attachments
+blockAttachments: false 

--- a/ansible/group_vars/uac.yml
+++ b/ansible/group_vars/uac.yml
@@ -2,3 +2,9 @@
 use_uac: true
 auth_services: ["github"]
 gitlab_url: "https://gitlab.com"
+
+
+# The custom private config is anything that might go inside the private-config.json
+#    needed for UAC.  It will be used by the ansible templating feature.
+
+#custom_private_config: "Enter your custom template info here"

--- a/ansible/roles/common/handlers/build-private-config.yml
+++ b/ansible/roles/common/handlers/build-private-config.yml
@@ -1,0 +1,44 @@
+# If the private-config is not there, then ask the user for the input information
+
+# Ask if GitHub authentication
+- pause:
+    prompt: "\tPlease enter the GitHub application client ID: "
+  listen: Private Config Tested          
+  #when: '"github" in auth_services and not (private_vol_stat.stat.exists)'
+  when: '"github" in auth_services'
+  register: github_clientID_register
+
+- pause:
+    prompt: "\n\tPlease enter the GitHub application client secret: '"
+  listen: Private Config Tested
+  #when: '"github" in auth_services and not (private_vol_stat.stat.exists)'
+  when: '"github" in auth_services'
+  register: github_clientSecret_register
+
+# Git Gitlab info
+- pause:
+    prompt: "\n\tPlease enter the GitLb application client ID:'"
+  listen: Private Config Tested    
+  #when: '"gitlab" in auth_services and not (private_vol_stat.stat.exists)'
+  when: '"gitlab" in auth_services'
+  register: gitlab_clientID_register
+
+- pause:
+    prompt: "\n\tPlease enter the GitLb application client secret:"
+  listen: Private Config Tested    
+  #when: '"gitlab" in auth_services and not (private_vol_stat.stat.exists)'
+  when: '"gitlab" in auth_services'
+  register: gitlab_clientSecret_register
+  
+# Session and JWT standard secret information      
+- pause:
+    prompt: "Enter JWT secret "
+  #when: "not (private_vol_stat.stat.exists)"    
+  listen: Private Config Tested    
+  register: secret_jwt_register
+
+- pause:
+    prompt: "Enter session secret "
+  #when: "not (private_vol_stat.stat.exists)"      
+  listen: Private Config Tested    
+  register: secret_session_register

--- a/ansible/roles/common/handlers/private-volume.yml
+++ b/ansible/roles/common/handlers/private-volume.yml
@@ -19,50 +19,20 @@
     - docker cp {{ private_vol }}/private-config.json helper:/config/private
     - docker rm helper
 
-# If the private-config is not there, then ask the user for the input information
 
-# Ask if GitHub authentication
-- pause:
-    prompt: "\tPlease enter the GitHub application client ID: "
-  listen: Private Config Tested          
-  when: '"github" in auth_services and not (private_vol_stat.stat.exists)'
-  register: github_clientID_register
-
-- pause:
-    prompt: "\n\tPlease enter the GitHub application client secret: '"
-  listen: Private Config Tested
-  when: '"github" in auth_services and not (private_vol_stat.stat.exists)'
-  register: github_clientSecret_register
-
-# Git Gitlab info
-- pause:
-    prompt: "\n\tPlease enter the GitLb application client ID:'"
-  listen: Private Config Tested    
-  when: '"gitlab" in auth_services and not (private_vol_stat.stat.exists)'
-  register: gitlab_clientID_register
-- pause:
-    prompt: "\n\tPlease enter the GitLb application client secret:"
-  listen: Private Config Tested    
-  when: '"gitlab" in auth_services and not (private_vol_stat.stat.exists)'
-  register: gitlab_clientSecret_register
-  
-# Session and JWT standard secret information      
-- pause:
-    prompt: "Enter JWT secret "
-  when: "not (private_vol_stat.stat.exists)"    
-  listen: Private Config Tested    
-  register: secret_jwt_register
-
-- pause:
-    prompt: "Enter session secret "
-  when: "not (private_vol_stat.stat.exists)"      
-  listen: Private Config Tested    
-  register: secret_session_register
-
+- name: include tasks to build the private config file
+  import_tasks: build-private-config.yml
+  when: 'not (private_vol_stat.stat.exists)'
 # Create The backup directory if it doesn't exist
+
+
+
+
 - name: Create Directory
   listen: Private Config Tested    
   file: path={{ private_vol }} state=directory
+
+- meta: flush_handlers
 
 # Create the new private-config.json.  Then, restart to first handler to copy the private-config
 - name: Private Config Tested Config

--- a/ansible/roles/common/tasks/api-reconfig.yml
+++ b/ansible/roles/common/tasks/api-reconfig.yml
@@ -9,11 +9,29 @@
 ####################################################################################
 
 
-- name: check-private
-  listen: load private-vol
-  stat:
-    path: '{{ private_vol }}/private-config.json'
-  register: private_vol_stat
+- debug: msg="Forcing Reconfigure of the Private Config"
   changed_when: True  
-  notify:
-    - Private Config Tested
+
+- name: include tasks to build the private config file
+  include_tasks: handlers/build-private-config.yml
+   
+
+- name: Create Directory2
+  file: path={{ private_vol }} state=directory
+
+
+
+# Create the new private-config.json.  Then, restart to first handler to copy the private-config
+- name: Private Config Tested Config2
+  #when: "not (private_vol_stat.stat.exists)"
+  template:
+    src: private-config.j2
+    dest: "{{ private_vol }}/private-config.json"
+
+# The private file exists.  So, copy it into the volume
+- name: Restore Private From Backup1
+  command: "{{ item }}"
+  with_items:
+    - docker run -v private-config:/config/private --name helper busybox true
+    - docker cp {{ private_vol }}/private-config.json helper:/config/private
+    - docker rm helper

--- a/ansible/roles/common/templates/private-config.j2
+++ b/ansible/roles/common/templates/private-config.j2
@@ -19,7 +19,12 @@
         "clientSecret": "{{ gitlab_clientSecret_register.user_input }}",
         "gitlabURL": "{{ gitlab_url }}"
     },
-    {% endif %}    
+    {% endif %}
+    {% if blockAttachments is defined %}    
+    "blockAttachments":{% if blockAttachments %}true,{% else %}false,{%endif%}
+    {% else %}
+        "blockAttachments": true,
+    {% endif %}
     "jwtSecret": "{{ secret_jwt_register.user_input }}",
     "sessionSecret": "{{ secret_session_register.user_input }}",
     "apiRoot": "https://{{ api_domain }}/api",

--- a/ansible/roles/common/templates/private-config.j2
+++ b/ansible/roles/common/templates/private-config.j2
@@ -23,7 +23,7 @@
     {% if block_attachments is defined %}    
     "blockAttachments":{% if block_attachments %}true,{% else %}false,{%endif%}
     {% else %}
-        "blockAttachments": true,
+        "blockAttachments": false,
     {% endif %}
     "jwtSecret": "{{ secret_jwt_register.user_input }}",
     "sessionSecret": "{{ secret_session_register.user_input }}",

--- a/ansible/roles/common/templates/private-config.j2
+++ b/ansible/roles/common/templates/private-config.j2
@@ -1,4 +1,8 @@
 {
+
+    {% if custom_private_config is defined %}
+        {{ custom_private_config }}
+    {% endif %}
     "authServices": [
         "{{ auth_services | join('",
         "') }}"

--- a/ansible/roles/common/templates/private-config.j2
+++ b/ansible/roles/common/templates/private-config.j2
@@ -20,8 +20,8 @@
         "gitlabURL": "{{ gitlab_url }}"
     },
     {% endif %}
-    {% if blockAttachments is defined %}    
-    "blockAttachments":{% if blockAttachments %}true,{% else %}false,{%endif%}
+    {% if block_attachments is defined %}    
+    "blockAttachments":{% if block_attachments %}true,{% else %}false,{%endif%}
     {% else %}
         "blockAttachments": true,
     {% endif %}


### PR DESCRIPTION
When the private-config.json is created, it will look for a group/host variable called 'custom_private_config' and will add that data to the top of the private-config.json

It will also look for a block_attachments variable, setting the value of true or false in the private-config.json

TO TEST
in group_vars/uac.yml, change the "custom_private_config" to something noticeable.
look at the block_attachments in group_vars/all.yml
ansible-playbook task-reconfigure-private-vol.yml
cat backup/private-vol/private-config.json

