### PR TITLE
Publish Ports in Development

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -23,4 +23,4 @@ legacy: false
 
 
 #  Turn to "true" if you would like to block attachments
-blockAttachments: false 
+block_attachments: false 

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -20,3 +20,7 @@ attachments_max_size: 0
 ansible_python_interpreter: python
 latest_production_tag: 0.3.9
 legacy: false
+
+
+#  Turn to "true" if you would like to block attachments
+blockAttachments: false 

--- a/ansible/group_vars/uac.yml
+++ b/ansible/group_vars/uac.yml
@@ -2,3 +2,9 @@
 use_uac: true
 auth_services: ["github"]
 gitlab_url: "https://gitlab.com"
+
+
+# The custom private config is anything that might go inside the private-config.json
+#    needed for UAC.  It will be used by the ansible templating feature.
+
+#custom_private_config: "Enter your custom template info here"

--- a/ansible/roles/api/tasks/main.yml
+++ b/ansible/roles/api/tasks/main.yml
@@ -27,6 +27,7 @@
       - name: "{{ docker_network_name }}"          
     volumes: "{{ volume_list }}"
 
+    published_ports: "{{ '49360:3000,5555:5555' if 'development' in group_names else [] }}"
     env:
       CTF_PARSE_HOST: http://unfetter-ctf-ingest
       STIX_API_PROTOCOL: http

--- a/ansible/roles/common/handlers/build-private-config.yml
+++ b/ansible/roles/common/handlers/build-private-config.yml
@@ -1,0 +1,44 @@
+# If the private-config is not there, then ask the user for the input information
+
+# Ask if GitHub authentication
+- pause:
+    prompt: "\tPlease enter the GitHub application client ID: "
+  listen: Private Config Tested          
+  #when: '"github" in auth_services and not (private_vol_stat.stat.exists)'
+  when: '"github" in auth_services'
+  register: github_clientID_register
+
+- pause:
+    prompt: "\n\tPlease enter the GitHub application client secret: '"
+  listen: Private Config Tested
+  #when: '"github" in auth_services and not (private_vol_stat.stat.exists)'
+  when: '"github" in auth_services'
+  register: github_clientSecret_register
+
+# Git Gitlab info
+- pause:
+    prompt: "\n\tPlease enter the GitLb application client ID:'"
+  listen: Private Config Tested    
+  #when: '"gitlab" in auth_services and not (private_vol_stat.stat.exists)'
+  when: '"gitlab" in auth_services'
+  register: gitlab_clientID_register
+
+- pause:
+    prompt: "\n\tPlease enter the GitLb application client secret:"
+  listen: Private Config Tested    
+  #when: '"gitlab" in auth_services and not (private_vol_stat.stat.exists)'
+  when: '"gitlab" in auth_services'
+  register: gitlab_clientSecret_register
+  
+# Session and JWT standard secret information      
+- pause:
+    prompt: "Enter JWT secret "
+  #when: "not (private_vol_stat.stat.exists)"    
+  listen: Private Config Tested    
+  register: secret_jwt_register
+
+- pause:
+    prompt: "Enter session secret "
+  #when: "not (private_vol_stat.stat.exists)"      
+  listen: Private Config Tested    
+  register: secret_session_register

--- a/ansible/roles/common/handlers/private-volume.yml
+++ b/ansible/roles/common/handlers/private-volume.yml
@@ -19,50 +19,20 @@
     - docker cp {{ private_vol }}/private-config.json helper:/config/private
     - docker rm helper
 
-# If the private-config is not there, then ask the user for the input information
 
-# Ask if GitHub authentication
-- pause:
-    prompt: "\tPlease enter the GitHub application client ID: "
-  listen: Private Config Tested          
-  when: '"github" in auth_services and not (private_vol_stat.stat.exists)'
-  register: github_clientID_register
-
-- pause:
-    prompt: "\n\tPlease enter the GitHub application client secret: '"
-  listen: Private Config Tested
-  when: '"github" in auth_services and not (private_vol_stat.stat.exists)'
-  register: github_clientSecret_register
-
-# Git Gitlab info
-- pause:
-    prompt: "\n\tPlease enter the GitLb application client ID:'"
-  listen: Private Config Tested    
-  when: '"gitlab" in auth_services and not (private_vol_stat.stat.exists)'
-  register: gitlab_clientID_register
-- pause:
-    prompt: "\n\tPlease enter the GitLb application client secret:"
-  listen: Private Config Tested    
-  when: '"gitlab" in auth_services and not (private_vol_stat.stat.exists)'
-  register: gitlab_clientSecret_register
-  
-# Session and JWT standard secret information      
-- pause:
-    prompt: "Enter JWT secret "
-  when: "not (private_vol_stat.stat.exists)"    
-  listen: Private Config Tested    
-  register: secret_jwt_register
-
-- pause:
-    prompt: "Enter session secret "
-  when: "not (private_vol_stat.stat.exists)"      
-  listen: Private Config Tested    
-  register: secret_session_register
-
+- name: include tasks to build the private config file
+  import_tasks: build-private-config.yml
+  when: 'not (private_vol_stat.stat.exists)'
 # Create The backup directory if it doesn't exist
+
+
+
+
 - name: Create Directory
   listen: Private Config Tested    
   file: path={{ private_vol }} state=directory
+
+- meta: flush_handlers
 
 # Create the new private-config.json.  Then, restart to first handler to copy the private-config
 - name: Private Config Tested Config

--- a/ansible/roles/common/tasks/api-reconfig.yml
+++ b/ansible/roles/common/tasks/api-reconfig.yml
@@ -9,11 +9,29 @@
 ####################################################################################
 
 
-- name: check-private
-  listen: load private-vol
-  stat:
-    path: '{{ private_vol }}/private-config.json'
-  register: private_vol_stat
+- debug: msg="Forcing Reconfigure of the Private Config"
   changed_when: True  
-  notify:
-    - Private Config Tested
+
+- name: include tasks to build the private config file
+  include_tasks: handlers/build-private-config.yml
+   
+
+- name: Create Directory2
+  file: path={{ private_vol }} state=directory
+
+
+
+# Create the new private-config.json.  Then, restart to first handler to copy the private-config
+- name: Private Config Tested Config2
+  #when: "not (private_vol_stat.stat.exists)"
+  template:
+    src: private-config.j2
+    dest: "{{ private_vol }}/private-config.json"
+
+# The private file exists.  So, copy it into the volume
+- name: Restore Private From Backup1
+  command: "{{ item }}"
+  with_items:
+    - docker run -v private-config:/config/private --name helper busybox true
+    - docker cp {{ private_vol }}/private-config.json helper:/config/private
+    - docker rm helper

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -50,6 +50,8 @@
 
 - meta: flush_handlers
 # Create the cti-stix-store-repository docker container
+
+
 - name: Create Repository
   docker_container:
     name: cti-stix-store-repository
@@ -63,8 +65,8 @@
     volumes:
 #    - "{{ prepath }}/unfetter/data/db:/data/db"
     - "mongo-db:/data/db"
-    published_ports:
-    - "27018:27017"
-  when: run_action 
+    published_ports: "{{ '27018:27017' if 'development' in group_names else [] }}"
 
+  when: run_action
+    
 

--- a/ansible/roles/common/templates/private-config.j2
+++ b/ansible/roles/common/templates/private-config.j2
@@ -19,7 +19,12 @@
         "clientSecret": "{{ gitlab_clientSecret_register.user_input }}",
         "gitlabURL": "{{ gitlab_url }}"
     },
-    {% endif %}    
+    {% endif %}
+    {% if blockAttachments is defined %}    
+    "blockAttachments":{% if blockAttachments %}true,{% else %}false,{%endif%}
+    {% else %}
+        "blockAttachments": true,
+    {% endif %}
     "jwtSecret": "{{ secret_jwt_register.user_input }}",
     "sessionSecret": "{{ secret_session_register.user_input }}",
     "apiRoot": "https://{{ api_domain }}/api",

--- a/ansible/roles/common/templates/private-config.j2
+++ b/ansible/roles/common/templates/private-config.j2
@@ -23,7 +23,7 @@
     {% if block_attachments is defined %}    
     "blockAttachments":{% if block_attachments %}true,{% else %}false,{%endif%}
     {% else %}
-        "blockAttachments": true,
+        "blockAttachments": false,
     {% endif %}
     "jwtSecret": "{{ secret_jwt_register.user_input }}",
     "sessionSecret": "{{ secret_session_register.user_input }}",

--- a/ansible/roles/common/templates/private-config.j2
+++ b/ansible/roles/common/templates/private-config.j2
@@ -1,4 +1,8 @@
 {
+
+    {% if custom_private_config is defined %}
+        {{ custom_private_config }}
+    {% endif %}
     "authServices": [
         "{{ auth_services | join('",
         "') }}"

--- a/ansible/roles/common/templates/private-config.j2
+++ b/ansible/roles/common/templates/private-config.j2
@@ -20,8 +20,8 @@
         "gitlabURL": "{{ gitlab_url }}"
     },
     {% endif %}
-    {% if blockAttachments is defined %}    
-    "blockAttachments":{% if blockAttachments %}true,{% else %}false,{%endif%}
+    {% if block_attachments is defined %}    
+    "blockAttachments":{% if block_attachments %}true,{% else %}false,{%endif%}
     {% else %}
         "blockAttachments": true,
     {% endif %}

--- a/ansible/roles/ingest/tasks/main.yml
+++ b/ansible/roles/ingest/tasks/main.yml
@@ -29,6 +29,7 @@
       - npm
       - start
     working_dir: /usr/share/unfetter-ctf-ingest
+    published_ports: "{{ '3001:10010' if 'development' in group_names else [] }}"
     env:
       API_PROTOCOL: https
       API_HOST: unfetter-discover-api

--- a/ansible/roles/pattern-handler/tasks/main.yml
+++ b/ansible/roles/pattern-handler/tasks/main.yml
@@ -16,18 +16,15 @@
 - debug:
       msg: "This is {{ build_action }}"
 # Create the pattern-handler 
-- name: Create pattern
+- name: Create pattern in production
   docker_container:
     name: "{{ container_name }}"
     image: "{{ image_name }}"
     state: started
     working_dir: /opt/stix/
+    published_ports: "{{ '5000:5000' if 'development' in group_names else [] }}"
     networks:
       - name: "{{ docker_network_name }}"          
-    exposed_ports: 
-    - "5000"
-    published_ports:
-    - "5000:5000"    
     entrypoint:
       - gunicorn
       - --config
@@ -36,6 +33,5 @@
       - "-"
       - app:app      
   when: run_action
-
 
 

--- a/ansible/roles/socket-server/tasks/main.yml
+++ b/ansible/roles/socket-server/tasks/main.yml
@@ -29,6 +29,7 @@
      - run
      - "{{ 'start' if run_mode == 'dev' else 'start:deploy' }}"
     working_dir: /usr/share/unfetter-socket-server
+    published_ports: "{{ '13333:3333,6555:6555' if 'development' in group_names else [] }}"
     env:
       MONGO_REPOSITORY: cti-stix-store-repository
       MONGO_PORT: 27017


### PR DESCRIPTION
When deploying a development stack, the ports are published for the containers.  When in production mode, only the nginx container is published

To test:

make sure that your "deployed" group has "prod-uac"

```
ansible-playbook deployed.yml
docker ps
```
only the gateway should have an exposed port.  You know the port is exposed because it will start with 0.0.0.0 in the ports colume

stop and remove all containers

```
ansible-playbook deploy-dev.yml
docker ps
```
There should be exposed ports for ingest, socket server, api, mongo, pattern handler
ingest: "3001:10010"
socket: "13333:3333", "6555:6555"
api: "49360:3000", "5555:5555"
mongo: "27018:27017"
pattern-handler: "5000:5000"