### PR TITLE
Issue 1429

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -18,7 +18,7 @@ use_taxii_tls: false
 # 0 means there is no size limit
 attachments_max_size: 0
 ansible_python_interpreter: python
-latest_production_tag: 0.3.9
+latest_production_tag: 0.3.10
 legacy: false
 
 

--- a/ansible/group_vars/production.yml
+++ b/ansible/group_vars/production.yml
@@ -22,5 +22,5 @@ ansible_python_interpreter: python
 build_action: "none"
 use_unfetter_ui: false
 run_mode: "prod"
-registry: ""
+registry: "unfetter/"
 

--- a/ansible/group_vars/production.yml
+++ b/ansible/group_vars/production.yml
@@ -13,7 +13,7 @@ ansible_ssh_private_key_file: ""
 ansible_connection: "local"
 # If local, then use ../../ or the full directory path to the directory above the "unfetter" directory.  
 prepath: '../../'
-docker_tag: "0.3.9"
+docker_tag: "0.3.10"
 gateway_tag: "{{ docker_tag }}.uac"
 
 ansible_python_interpreter: python
@@ -22,5 +22,5 @@ ansible_python_interpreter: python
 build_action: "none"
 use_unfetter_ui: false
 run_mode: "prod"
-registry: "unfetter/"
+registry: ""
 

--- a/ansible/roles/gateway/files/Dockerfile
+++ b/ansible/roles/gateway/files/Dockerfile
@@ -1,6 +1,0 @@
-FROM nginx:1.13.5-alpine
-
-LABEL maintainer "unfetter"
-LABEL Description="Nginx server with compiled unfetter ui files"
-
-COPY ./dist /etc/nginx/html

--- a/ansible/roles/gateway/tasks/main.yml
+++ b/ansible/roles/gateway/tasks/main.yml
@@ -21,13 +21,13 @@
 #  when: "('production' in group_names and build_action=='local')"
     
     
-- name: "Build {{ container_name }} from Gateway Dockerfile"
-  docker_image:
-    name: "{{ container_name }}"
-    tag: "{{ gateway_tag }}"
-    state: present
-    path: "{{ remote_role_directory }}files"
-  when: "('production' in group_names and build_action=='local')"
+#- name: "Build {{ container_name }} from Gateway Dockerfile"
+#  docker_image:
+#    name: "{{ container_name }}"
+#    tag: "{{ gateway_tag }}"
+#    state: present
+#    path: "{{ remote_role_directory }}files"
+#  when: "('production' in group_names and build_action=='local')"
 
 - name: make sure dirs are there
   file: path={{ role_path }}/files/conf.d/ state=directory


### PR DESCRIPTION
When building for production, then running the deploy.yml for production locally, it was using an old unfetter-discover-gateway.

We also could not run tests of production from locally built Unfetter images because it was always pulling from the registry


To test:

ansible-playbook build-prod.yml -e "registry= docker_tag=testtag"
ansible-playbook deploy.yml -e "registry= docker_tag=testtag"
View to see if it worked.

Change the hosts.ini [deployed] to uac, legacy, etc and rerun the deploy
