### PR TITLE
Removed the "latest production tag"

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -18,7 +18,6 @@ use_taxii_tls: false
 # 0 means there is no size limit
 attachments_max_size: 0
 ansible_python_interpreter: python
-latest_production_tag: 0.3.11
 legacy: false
 
 

--- a/ansible/group_vars/production.yml
+++ b/ansible/group_vars/production.yml
@@ -13,7 +13,7 @@ ansible_ssh_private_key_file: ""
 ansible_connection: "local"
 # If local, then use ../../ or the full directory path to the directory above the "unfetter" directory.  
 prepath: '../../'
-docker_tag: "0.3.11"
+docker_tag: "0.3.10"
 gateway_tag: "{{ docker_tag }}.uac"
 
 ansible_python_interpreter: python

--- a/ansible/hosts.ini
+++ b/ansible/hosts.ini
@@ -15,12 +15,12 @@ dev
 #  The production group specifies that the docker images will come from a registery, likely Docker Hub.
 [production]
 
-prod-uac gateway_tag="{{ latest_production_tag }}.uac"
-prod-demo gateway_tag="{{ latest_production_tag }}.demo"
-prod-legacy-uac gateway_tag="{{ latest_production_tag }}.legacy.uac" legacy=true
-prod-legacy-demo gateway_tag="{{ latest_production_tag }}.legacy.demo" legacy=true
+prod-uac gateway_tag="{{ docker_tag }}.uac"
+prod-demo gateway_tag="{{ docker_tag }}.demo"
+prod-legacy-uac gateway_tag="{{ docker_tag }}.legacy.uac" legacy=true
+prod-legacy-demo gateway_tag="{{ docker_tag }}.legacy.demo" legacy=true
 
-build docker_tag="{{ latest_production_tag }}" registry="" build_action="local" run_action=false 
+build docker_tag="{{ docker_tag }}" registry="" build_action="local" run_action=false 
 
 # UAC group says that UAC for github/gitlab will be turned on.
 [uac]


### PR DESCRIPTION
Rather than have two different variables for tagging docker images, just make docker_tag variable different in production.yml and all.yml

There should be no change in running ansible.