### PR TITLE
Issue 1449

### DIFF
--- a/ansible/.gitignore
+++ b/ansible/.gitignore
@@ -9,3 +9,6 @@ backup/*
 
 roles/gateway/files/conf.d/default.conf
 roles/gateway/files/ui-dist/
+
+host_vars/*
+!host_vars/demo-file.yml

--- a/ansible/Pipfile
+++ b/ansible/Pipfile
@@ -5,3 +5,5 @@ name = "pypi"
 
 [packages]
 docker-py = "*"
+boto3 = "*"
+boto = "*"

--- a/ansible/Pipfile.lock
+++ b/ansible/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bf19a0261a34a75251f5fdcb5d779e84b6bbdc1ad90ea93f1922062f5ba37e22"
+            "sha256": "70dd1d4e9b75fe747b326ef18a07d5ff6c1718527a7a7411148bc36444d6c241"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -14,6 +14,29 @@
         ]
     },
     "default": {
+        "boto": {
+            "hashes": [
+                "sha256:147758d41ae7240dc989f0039f27da8ca0d53734be0eb869ef16e3adcfa462e8",
+                "sha256:ea0d3b40a2d852767be77ca343b58a9e3a4b00d9db440efb8da74b4e58025e5a"
+            ],
+            "index": "pypi",
+            "version": "==2.49.0"
+        },
+        "boto3": {
+            "hashes": [
+                "sha256:22520c2b71eb4c129b5bdddc6adb62e52c4076d02884d532008bdb0289277e3a",
+                "sha256:fc09c0f0fa6f344c941c4102d78cf2a04a13640d81a34f44b7df0b0ecbbdd36b"
+            ],
+            "index": "pypi",
+            "version": "==1.9.11"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:b89d5ff4409247ac35ed94c59bdc81dc7956619682cd819434fef11f2b3bc7e8",
+                "sha256:f9d79c6bdf5d7ada6a929e2c91af9a17b0c49bed9647819780482425a57a2778"
+            ],
+            "version": "==1.12.11"
+        },
         "certifi": {
             "hashes": [
                 "sha256:376690d6f16d32f9d1fe8932551d80b23e9d393a8578c5633a2ed39a64861638",
@@ -43,6 +66,14 @@
             ],
             "version": "==0.3.0"
         },
+        "docutils": {
+            "hashes": [
+                "sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6",
+                "sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274",
+                "sha256:7a4bd47eaf6596e1295ecb11361139febe29b084a87bf005bf899f9a42edc3c6"
+            ],
+            "version": "==0.14"
+        },
         "idna": {
             "hashes": [
                 "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
@@ -50,12 +81,34 @@
             ],
             "version": "==2.7"
         },
+        "jmespath": {
+            "hashes": [
+                "sha256:6a81d4c9aa62caf061cb517b4d9ad1dd300374cd4706997aff9cd6aedd61fc64",
+                "sha256:f11b4461f425740a1d908e9a3f7365c3d2e569f6ca68a2ff8bc5bcd9676edd63"
+            ],
+            "version": "==0.9.3"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:1adb80e7a782c12e52ef9a8182bebeb73f1d7e24e374397af06fb4956c8dc5c0",
+                "sha256:e27001de32f627c22380a688bcc43ce83504a7bc5da472209b4c70f02829f0b8"
+            ],
+            "markers": "python_version >= '2.7'",
+            "version": "==2.7.3"
+        },
         "requests": {
             "hashes": [
                 "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
                 "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
             ],
             "version": "==2.19.1"
+        },
+        "s3transfer": {
+            "hashes": [
+                "sha256:90dc18e028989c609146e241ea153250be451e05ecc0c2832565231dacdf59c1",
+                "sha256:c7a9ec356982d5e9ab2d4b46391a7d6a950e2b04c472419f5fdec70cc0ada72f"
+            ],
+            "version": "==0.1.13"
         },
         "six": {
             "hashes": [
@@ -69,15 +122,15 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
-            "markers": "python_version != '3.3.*' and python_version >= '2.6' and python_version != '3.1.*' and python_version != '3.2.*' and python_version < '4' and python_version != '3.0.*'",
+            "markers": "python_version != '3.3.*' and python_version != '3.2.*' and python_version < '4' and python_version >= '2.6' and python_version != '3.1.*' and python_version != '3.0.*'",
             "version": "==1.23"
         },
         "websocket-client": {
             "hashes": [
-                "sha256:03763384c530b331ec3822d0b52ffdc28c3aeb8a900ac8c98b2ceea3128a7b4e",
-                "sha256:3c9924675eaf0b27ae22feeeab4741bb4149b94820bd3a143eeaf8b62f64d821"
+                "sha256:c42b71b68f9ef151433d6dcc6a7cb98ac72d2ad1e3a74981ca22bc5d9134f166",
+                "sha256:f5889b1d0a994258cfcbc8f2dc3e457f6fc7b32a8d74873033d12e4eab4bdf63"
             ],
-            "version": "==0.52.0"
+            "version": "==0.53.0"
         }
     },
     "develop": {}

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,2 +1,3 @@
 [defaults]
 inventory = hosts.ini
+host_key_check = False

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -18,7 +18,10 @@ use_taxii_tls: false
 # 0 means there is no size limit
 attachments_max_size: 0
 ansible_python_interpreter: python
-latest_production_tag: 0.3.11
+docker_tag: "0.3.11"
+latest_production_tag: "{{ docker_tag }}"
+gateway_tag: "{{ docker_tag }}.uac"
+
 legacy: false
 
 

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -17,7 +17,7 @@ use_taxii_tls: false
 # Parameter pasted to nginx's `client_max_body_size` variable for attachments being uploaded to the API
 # 0 means there is no size limit
 attachments_max_size: 0
-ansible_python_interpreter: python
+ansible_python_interpreter: python3
 latest_production_tag: 0.3.11
 legacy: false
 

--- a/ansible/group_vars/production.yml
+++ b/ansible/group_vars/production.yml
@@ -16,8 +16,6 @@ prepath: '../../'
 docker_tag: "0.3.11"
 gateway_tag: "{{ docker_tag }}.uac"
 
-ansible_python_interpreter: python
-
 # Docker Tag specifies what will be the name of the developed tag.
 build_action: "none"
 use_unfetter_ui: false

--- a/ansible/group_vars/production.yml
+++ b/ansible/group_vars/production.yml
@@ -16,7 +16,7 @@ prepath: '../../'
 docker_tag: "0.3.11"
 gateway_tag: "{{ docker_tag }}.uac"
 
-ansible_python_interpreter: python
+ansible_python_interpreter: python3
 
 # Docker Tag specifies what will be the name of the developed tag.
 build_action: "none"

--- a/ansible/host_vars/demo-file.yml
+++ b/ansible/host_vars/demo-file.yml
@@ -1,0 +1,10 @@
+---
+remote_tmp: ""
+ansible_connection: "ssh"
+backup_directory: "{{ remote_tmp }}/unfetter"
+ansible_user: "ansible"
+ansible_ssh_private_key_file: "xxxxxxx"
+ansible_host: "xx.xx.xxx.xxx"
+api_domain: "{{ ansible_host }}"
+ui_domain: "{{ ansible_host }}"
+

--- a/ansible/hosts.ini
+++ b/ansible/hosts.ini
@@ -3,8 +3,8 @@
 
 [deployed]
 prod-uac
-
-
+#prod-demo
+#prod-legacy-uac
 
 # The development group of hosts will deploy with open ports, recompiling UI, and debug statements
 #  these should NEVER be used in production

--- a/ansible/hosts.ini
+++ b/ansible/hosts.ini
@@ -4,7 +4,7 @@
 [deployed]
 prod-uac
 prod-demo
-
+prod-legacy-uac
 
 # The development group of hosts will deploy with open ports, recompiling UI, and debug statements
 #  these should NEVER be used in production

--- a/ansible/hosts.ini
+++ b/ansible/hosts.ini
@@ -3,7 +3,7 @@
 
 [deployed]
 prod-uac
-
+prod-demo
 
 
 # The development group of hosts will deploy with open ports, recompiling UI, and debug statements

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,0 +1,7 @@
+## The Ansible Galaxy Modules needed
+#  $ ansible-galaxy install -r requirements.yml
+
+- src: geerlingguy.docker
+- src: geerlingguy.git
+- src: geerlingguy.pip
+

--- a/ansible/roles/unfetter/tasks/generate-ssh-keys.yml
+++ b/ansible/roles/unfetter/tasks/generate-ssh-keys.yml
@@ -1,11 +1,5 @@
   - name: Generate RSA keys at {{ key_location }}
     delegate_to: localhost
-<<<<<<< HEAD
-    command : 'ssh-keygen -q -t rsa -f /home/srmccul/.ssh/ansible -C "" -N ""'
-    args:
-       creates: /home/srmccul/.ssh/ansible 
-=======
     command : 'ssh-keygen -q -t rsa -f {{ ansible_ssh_private_key_file }} -C "" -N ""'
     args:
        creates: "{{ ansible_ssh_private_key_file }}"
->>>>>>> f4ca231621f58e8789e1ed892ea89a2f84f182c0

--- a/ansible/roles/unfetter/tasks/generate-ssh-keys.yml
+++ b/ansible/roles/unfetter/tasks/generate-ssh-keys.yml
@@ -1,0 +1,9 @@
+---
+- hosts: all
+  become: true
+  gather_facts: false
+
+  tasks:
+  - name: Generate /etc/ssh/ RSA host key
+    command : ssh-keygen -q -t rsa -f /etc/ssh/ssh_host_rsa_key -C "" -N ""
+    creates: /etc/ssh/ssh_host_rsa_key

--- a/ansible/roles/unfetter/tasks/generate-ssh-keys.yml
+++ b/ansible/roles/unfetter/tasks/generate-ssh-keys.yml
@@ -1,9 +1,6 @@
 ---
-- hosts: all
-  become: true
-  gather_facts: false
 
   tasks:
   - name: Generate /etc/ssh/ RSA host key
-    command : ssh-keygen -q -t rsa -f /etc/ssh/ssh_host_rsa_key -C "" -N ""
-    creates: /etc/ssh/ssh_host_rsa_key
+    command : ssh-keygen -q -t rsa -f {{ key_location }} -C "" -N ""
+    creates: "{{ key_location }}"

--- a/ansible/roles/unfetter/tasks/generate-ssh-keys.yml
+++ b/ansible/roles/unfetter/tasks/generate-ssh-keys.yml
@@ -1,6 +1,5 @@
----
-
-  tasks:
-  - name: Generate /etc/ssh/ RSA host key
-    command : ssh-keygen -q -t rsa -f {{ key_location }} -C "" -N ""
-    creates: "{{ key_location }}"
+  - name: Generate RSA keys at {{ key_location }}
+    delegate_to: localhost
+    command : 'ssh-keygen -q -t rsa -f /home/srmccul/.ssh/ansible -C "" -N ""'
+    args:
+       creates: /home/srmccul/.ssh/ansible 

--- a/ansible/roles/unfetter/tasks/generate-ssh-keys.yml
+++ b/ansible/roles/unfetter/tasks/generate-ssh-keys.yml
@@ -1,0 +1,5 @@
+  - name: Generate RSA keys at {{ key_location }}
+    delegate_to: localhost
+    command : 'ssh-keygen -q -t rsa -f {{ ansible_ssh_private_key_file }} -C "" -N ""'
+    args:
+       creates: "{{ ansible_ssh_private_key_file }}"

--- a/ansible/roles/unfetter/tasks/host-packages.yml
+++ b/ansible/roles/unfetter/tasks/host-packages.yml
@@ -2,7 +2,7 @@
 
 
 
-- name: Clone Unfetter Git
+- name: Clone Unfetter Git to {{ prepath }}
   git:
      repo: "https://github.com/unfetter-discover/unfetter.git"
      dest: "{{ prepath }}unfetter"

--- a/ansible/roles/unfetter/tasks/host-packages.yml
+++ b/ansible/roles/unfetter/tasks/host-packages.yml
@@ -1,0 +1,23 @@
+# Ensure the volumes are created. 
+
+
+- name: Clone Unfetter Git to {{ backup_directory }}/code
+  git:
+     repo: "https://github.com/unfetter-discover/unfetter.git"
+     dest: "{{ backup_directory }}/code/unfetter"
+     version: "{{ branch }}"
+     force: yes
+
+- name: Clone if in Development (and will run locally)
+  when: "('development' in group_names)"
+  git:
+     repo: "https://github.com/unfetter-discover/{{ item }}.git"
+     dest: "{{ backup_directory }}/code/{{ item }}"
+     version: "{{ branch }}"
+  loop:
+     - unfetter
+     - unfetter-store
+     - unfetter-ui
+     - stix2pattern
+
+

--- a/ansible/roles/unfetter/tasks/host-packages.yml
+++ b/ansible/roles/unfetter/tasks/host-packages.yml
@@ -1,13 +1,6 @@
 # Ensure the volumes are created. 
 
 
-- name: Clone Unfetter Git to {{ backup_directory }}/code
-  git:
-     repo: "https://github.com/unfetter-discover/unfetter.git"
-     dest: "{{ backup_directory }}/code/unfetter"
-     version: "{{ branch }}"
-     force: yes
-
 - name: Clone if in Development (and will run locally)
   when: "('development' in group_names)"
   git:

--- a/ansible/roles/unfetter/tasks/host-packages.yml
+++ b/ansible/roles/unfetter/tasks/host-packages.yml
@@ -2,6 +2,8 @@
 
 
 
+
+
 - name: Clone Unfetter Git to {{ prepath }}
   git:
      repo: "https://github.com/unfetter-discover/unfetter.git"

--- a/ansible/roles/unfetter/tasks/host-packages.yml
+++ b/ansible/roles/unfetter/tasks/host-packages.yml
@@ -1,11 +1,16 @@
 # Ensure the volumes are created. 
+
+
+
 - name: Clone Unfetter Git
   git:
      repo: "https://github.com/unfetter-discover/unfetter.git"
      dest: "{{ prepath }}unfetter"
      version: "{{ branch }}"
+     force: yes
 
 - name: Clone if in Dev
+  when: "('development' in group_names)"
   git:
      repo: "https://github.com/unfetter-discover/{{ item }}.git"
      dest: "{{ prepath }}{{ item }}"

--- a/ansible/roles/unfetter/tasks/host-packages.yml
+++ b/ansible/roles/unfetter/tasks/host-packages.yml
@@ -11,13 +11,14 @@
      version: "{{ branch }}"
      force: yes
 
-- name: Clone if in Dev
+- name: Clone if in Development (and will run locally)
   when: "('development' in group_names)"
   git:
      repo: "https://github.com/unfetter-discover/{{ item }}.git"
      dest: "{{ backup_directory }}/code/{{ item }}"
      version: "{{ branch }}"
   loop:
+     - unfetter
      - unfetter-store
      - unfetter-ui
      - stix2pattern

--- a/ansible/roles/unfetter/tasks/host-packages.yml
+++ b/ansible/roles/unfetter/tasks/host-packages.yml
@@ -1,9 +1,4 @@
 # Ensure the volumes are created. 
-
-
-
-
-
 - name: Clone Unfetter Git to {{ backup_directory }}/code
   git:
      repo: "https://github.com/unfetter-discover/unfetter.git"

--- a/ansible/roles/unfetter/tasks/host-packages.yml
+++ b/ansible/roles/unfetter/tasks/host-packages.yml
@@ -1,0 +1,18 @@
+# Ensure the volumes are created. 
+- name: Clone Unfetter Git
+  git:
+     repo: "https://github.com/unfetter-discover/unfetter.git"
+     dest: "{{ prepath }}unfetter"
+     version: "{{ branch }}"
+
+- name: Clone if in Dev
+  git:
+     repo: "https://github.com/unfetter-discover/{{ item }}.git"
+     dest: "{{ prepath }}{{ item }}"
+     version: "{{ branch }}"
+  loop:
+     - unfetter-store
+     - unfetter-ui
+     - stix2pattern
+
+

--- a/ansible/roles/unfetter/tasks/host-packages.yml
+++ b/ansible/roles/unfetter/tasks/host-packages.yml
@@ -1,4 +1,6 @@
 # Ensure the volumes are created. 
+
+
 - name: Clone Unfetter Git to {{ backup_directory }}/code
   git:
      repo: "https://github.com/unfetter-discover/unfetter.git"

--- a/ansible/roles/unfetter/tasks/host-packages.yml
+++ b/ansible/roles/unfetter/tasks/host-packages.yml
@@ -4,10 +4,10 @@
 
 
 
-- name: Clone Unfetter Git to {{ prepath }}
+- name: Clone Unfetter Git to {{ backup_directory }}/code
   git:
      repo: "https://github.com/unfetter-discover/unfetter.git"
-     dest: "{{ prepath }}unfetter"
+     dest: "{{ backup_directory }}/code/unfetter"
      version: "{{ branch }}"
      force: yes
 
@@ -15,7 +15,7 @@
   when: "('development' in group_names)"
   git:
      repo: "https://github.com/unfetter-discover/{{ item }}.git"
-     dest: "{{ prepath }}{{ item }}"
+     dest: "{{ backup_directory }}/code/{{ item }}"
      version: "{{ branch }}"
   loop:
      - unfetter-store

--- a/ansible/roles/unfetter/tasks/main.yml
+++ b/ansible/roles/unfetter/tasks/main.yml
@@ -1,18 +1,10 @@
 # Ensure the volumes are created. 
-- name: Clone Unfetter Git
-  git:
-     repo: "https://github.com/unfetter-discover/unfetter.git"
-     dest: "{{ prepath }}unfetter"
-     version: "{{ branch }}"
+#- include_tasks: generate-ssh-keys.yml
 
-- name: Clone if in Dev
-  git:
-     repo: "https://github.com/unfetter-discover/{{ item }}.git"
-     dest: "{{ prepath }}{{ item }}"
-     version: "{{ branch }}"
-  loop:
-     - unfetter-store
-     - unfetter-ui
-     - stix2pattern
+#- meta: end_play
 
+- debug:
+  msg: Configuring and deploying {{ inventory_hostname }} at {{ ansible_host }}
 
+- name: configure the remote host with proper packages
+  include_tasks: host-packages.yml

--- a/ansible/roles/unfetter/tasks/main.yml
+++ b/ansible/roles/unfetter/tasks/main.yml
@@ -1,10 +1,11 @@
 # Ensure the volumes are created. 
+- name: Test for SSH keys
+  include_tasks: generate-ssh-keys.yml
 
+- meta: end_play
 
 - debug:
   msg: Configuring and deploying {{ inventory_hostname }} at {{ ansible_host }}
-
-- debug:
 
 - name: configure the remote host with proper packages
   include_tasks: host-packages.yml

--- a/ansible/roles/unfetter/tasks/main.yml
+++ b/ansible/roles/unfetter/tasks/main.yml
@@ -1,8 +1,7 @@
 # Ensure the volumes are created. 
-- name: Test for SSH keys
-  include_tasks: generate-ssh-keys.yml
+#- include_tasks: generate-ssh-keys.yml
 
-- meta: end_play
+#- meta: end_play
 
 - debug:
   msg: Configuring and deploying {{ inventory_hostname }} at {{ ansible_host }}

--- a/ansible/roles/unfetter/tasks/main.yml
+++ b/ansible/roles/unfetter/tasks/main.yml
@@ -1,18 +1,7 @@
 # Ensure the volumes are created. 
-- name: Clone Unfetter Git
-  git:
-     repo: "https://github.com/unfetter-discover/unfetter.git"
-     dest: "{{ prepath }}unfetter"
-     version: "{{ branch }}"
-
-- name: Clone if in Dev
-  git:
-     repo: "https://github.com/unfetter-discover/{{ item }}.git"
-     dest: "{{ prepath }}{{ item }}"
-     version: "{{ branch }}"
-  loop:
-     - unfetter-store
-     - unfetter-ui
-     - stix2pattern
 
 
+- debug:
+  msg: Configuring and deploying {{ inventory_hostname }} at {{ ansible_host }}
+- name: configure the remote host with proper packages
+  include_tasks: host-packages.yml

--- a/ansible/roles/unfetter/tasks/main.yml
+++ b/ansible/roles/unfetter/tasks/main.yml
@@ -8,3 +8,4 @@
 
 - name: configure the remote host with proper packages
   include_tasks: host-packages.yml
+  when: "('development' in group_names)"

--- a/ansible/roles/unfetter/tasks/main.yml
+++ b/ansible/roles/unfetter/tasks/main.yml
@@ -3,5 +3,8 @@
 
 - debug:
   msg: Configuring and deploying {{ inventory_hostname }} at {{ ansible_host }}
+
+- debug:
+
 - name: configure the remote host with proper packages
   include_tasks: host-packages.yml

--- a/ansible/roles/unfetter/vars/main.yml
+++ b/ansible/roles/unfetter/vars/main.yml
@@ -1,5 +1,5 @@
 ---
 
 # The VARS for building and preparing the Unfetter HOSTS for docker
-
-branch: "{{ 'develop' if run_mode == 'dev' else 'master'}}"
+key_location: "{{ ansible_ssh_private_key_file }}"
+branch: "{{ 'develop' if 'development' in group_names else 'master' }}"

--- a/ansible/roles/unfetter/vars/main.yml
+++ b/ansible/roles/unfetter/vars/main.yml
@@ -2,4 +2,4 @@
 
 # The VARS for building and preparing the Unfetter HOSTS for docker
 
-branch: "{{ 'develop' if run_mode == 'dev' else 'master'}}"
+branch: "{{ 'develop' if 'development' in group_names else 'master' }}"

--- a/ansible/roles/unfetter/vars/main.yml
+++ b/ansible/roles/unfetter/vars/main.yml
@@ -1,5 +1,5 @@
 ---
 
 # The VARS for building and preparing the Unfetter HOSTS for docker
-
+key_location: "{{ ansible_ssh_private_key_file }}"
 branch: "{{ 'develop' if 'development' in group_names else 'master' }}"

--- a/ansible/task-build-test-hosts.yml
+++ b/ansible/task-build-test-hosts.yml
@@ -1,0 +1,50 @@
+---
+####################################################################################
+# This Playbook will attempt to deploy EC2 instances, configured properly for testing
+#    and operation 
+#
+####################################################################################
+
+
+- name: Prepare the Docker Host 
+  hosts: 127.0.0.1
+  connection: local
+   
+#  become: true
+  vars:
+  tasks:
+
+ # - debug:
+ #     var: result
+
+
+  - debug:
+      msg: "{{ groups['deployed'] }}"
+#  - meta: end_play
+  - name: "Generate RSA keys at {{ hostvars[item].ansible_ssh_private_key_file }}"
+    delegate_to: localhost
+    command : 'ssh-keygen -q -t rsa -f {{ hostvars[item].ansible_ssh_private_key_file }} -C "" -N ""'
+    args:
+       creates:  "{{ hostvars[item].ansible_ssh_private_key_file }}" 
+    with_inventory_hostnames:
+       - deployed
+
+  - name: "Determine if EC2 instances are created"
+    ec2_instance_facts:
+        filters:
+            "tag:unfetter-deploy": "{{ groups['deployed'] }}"
+    register: ec2_facts
+#    with_inventory_hostnames:
+#        - deployed
+#  - meta: end_play
+
+#  - set_fact:
+#       ec2_output_json: "{{ ec2_fact_output_raw }}"
+  - debug:
+       msg: "{{ ec2_facts }}"
+  - debug: 
+      msg: "{{ item }} "
+    loop:  "{{ ec2_facts.instances|map(attribute='tags.Name')|list }}"
+#      - "{{ ec2_facts.results[0].instances|select('state', 'equalto', 'running')|map(attribute='private_ip_address')|list }}"
+         
+

--- a/ansible/task-build-test-hosts.yml
+++ b/ansible/task-build-test-hosts.yml
@@ -6,12 +6,13 @@
 ####################################################################################
 
 
-- name: Prepare the Docker Host 
-  hosts: 127.0.0.1
+- hosts: 127.0.0.1
   connection: local
    
 #  become: true
   vars:
+     private_key: "/home/srmccul/.ssh/ansible"
+     region: 'us-east-1'
   tasks:
 
  # - debug:
@@ -21,30 +22,98 @@
   - debug:
       msg: "{{ groups['deployed'] }}"
 #  - meta: end_play
-  - name: "Generate RSA keys at {{ hostvars[item].ansible_ssh_private_key_file }}"
-    delegate_to: localhost
-    command : 'ssh-keygen -q -t rsa -f {{ hostvars[item].ansible_ssh_private_key_file }} -C "" -N ""'
-    args:
-       creates:  "{{ hostvars[item].ansible_ssh_private_key_file }}" 
-    with_inventory_hostnames:
-       - deployed
+
+
+#   Removing for now so can focus on configuring already created EC2 
+#  - name: "Generate RSA keys at {{ private_key }}"
+#    delegate_to: localhost
+#    command : 'ssh-keygen -q -t rsa -f {{ private_key }} -C "" -N ""'
+#    args:
+#       creates:  "{{ private_key }}" 
+
+
+
+
+# I can't seem to get a list of the not found systems
+
 
   - name: "Determine if EC2 instances are created"
     ec2_instance_facts:
         filters:
             "tag:unfetter-deploy": "{{ groups['deployed'] }}"
-    register: ec2_facts
-#    with_inventory_hostnames:
-#        - deployed
-#  - meta: end_play
+#            "instance-state-code": "!0"            
 
-#  - set_fact:
-#       ec2_output_json: "{{ ec2_fact_output_raw }}"
+            "instance-state-name": 
+                 - "starting"
+                 - "running"
+                 - "pending"
+                 - "stopping"
+                 - "stopped"
+#            "instance-state-name": "pending"
+#            "instance-state-name": "running"
+#            "instance-state-name": "stopping"
+#            "instance-state-name": "stopped"
+
+    register: ec2_facts
+  - name: "showing groups['deployed']"
+    debug:
+      msg: "{{ groups['deployed'] }}"
+
+  - set_fact: 
+     deployed_names: []
+  - name: "building deployed_names"
+    set_fact: 
+      deployed_names: "{{ groups['deployed'] }}"
+#      with_items: "{{ groups['deployed'] }}"
   - debug:
-       msg: "{{ ec2_facts }}"
-  - debug: 
-      msg: "{{ item }} "
-    loop:  "{{ ec2_facts.instances|map(attribute='tags.Name')|list }}"
+       msg: "{{ item }}"
+    with_items: "{{ deployed_names }}"
+
+
+  - set_fact:
+      found_ec2: "{{ ec2_facts.instances|map(attribute='tags.unfetter-deploy')|list }}"
+  - name: "Display found"
+    debug:
+      var: found_ec2
+
+
+  - set_fact:
+       no_ec2_list: []
+  - set_fact: 
+       no_ec2_list: "{{ no_ec2_list|default([]) | union([item]) }}"
+    with_items: "{{ deployed_names }}"
+    when: item not in found_ec2 
+
+  - name: Failed if EC2's were not found
+    fail:
+       msg: "WARNING: The Following EC2 Instances have not been deployed: {{ no_ec2_list }}"
+    when: no_ec2_list|length > 0 
+
+
+  - name: "Start Stopped Instances"
+    ec2:
+       region: '{{ region }}'
+       instance_tags:
+          unfetter-deploy: "{{ item }}"
+       state: running
+    with_items: "{{ groups['deployed'] }}"
+
 #      - "{{ ec2_facts.results[0].instances|select('state', 'equalto', 'running')|map(attribute='private_ip_address')|list }}"
          
+# Get all the hosts that are created
+# Output what we think the IP is, and the actual IP information highlighting differences
+# Output any EC2 that have not been created
+# Create them
 
+# If no IP exists, then assign the IP based on what was found
+# Um, build the host vars.yml if it doesn't exist?
+#- name: begin configuration of hosts
+- hosts: deployed
+ 
+
+
+  tasks:
+     - debug: msg="play_hosts={{ play_hosts }}"
+  
+   
+ 

--- a/ansible/task-prep-remote-host.yml
+++ b/ansible/task-prep-remote-host.yml
@@ -7,9 +7,10 @@
 
 
 - name: Prepare the Docker Host 
-  hosts: deployed 
+  hosts: prod-legacy-uac 
 #  become: true
   vars:
+     ansible_python_interpreter: python
      pip_install_packages:
        - name: docker
   tasks:

--- a/ansible/task-prep-remote-host.yml
+++ b/ansible/task-prep-remote-host.yml
@@ -8,28 +8,12 @@
 
 - name: Prepare the Docker Host 
   hosts: deployed
-#  become: true
   vars:
      ansible_python_interpreter: python
      pip_install_packages:
        - name: docker
   
-
- # - debug:
- #     var: result
-  # pre_tasks:
-  #   - include_role:
-  #        name: unfetter
-  #        tasks_from: generate-ssh-keys.yml
   pre_tasks:
-    # -  name: Add {{ ansible_host }} as a user
-    #    user:
-    #       name: "{{ ansible_host }}"
-    #       groups: "wheel"
-    #       append: yes
-    #       comment: "The User we will run docker as"
-    #       state: present
-    #    become: true
 # This was necessary to get docker running on the AWS Linux 2 AMI
     - name: Install Docker CE CentOS-specific dependencies
       block:
@@ -62,7 +46,8 @@
     - { role: geerlingguy.docker, docker_users: ["{{ ansible_host }}"], become: true}
     - { role: geerlingguy.git, become: true }
     - { role: geerlingguy.pip, become: true }
-#    - unfetter  
+    #- unfetter
+
 
 
  

--- a/ansible/task-prep-remote-host.yml
+++ b/ansible/task-prep-remote-host.yml
@@ -1,7 +1,9 @@
 ---
 ####################################################################################
-# This Playbook will attempt to deploy EC2 instances, configured properly for testing
-#    and operation 
+#   This playbook will configure a remote host to support Unfetter, and will run
+#   a production version of Unfetter
+#
+#   
 #
 ####################################################################################
 

--- a/ansible/task-prep-remote-host.yml
+++ b/ansible/task-prep-remote-host.yml
@@ -7,23 +7,62 @@
 
 
 - name: Prepare the Docker Host 
-  hosts: prod-legacy-uac 
+  hosts: deployed
 #  become: true
   vars:
      ansible_python_interpreter: python
      pip_install_packages:
        - name: docker
-  tasks:
+  
 
  # - debug:
  #     var: result
+  # pre_tasks:
+  #   - include_role:
+  #        name: unfetter
+  #        tasks_from: generate-ssh-keys.yml
   pre_tasks:
-    - include_role:
-         name: unfetter
-         tasks_from: generate-ssh-keys.yml
+    # -  name: Add {{ ansible_host }} as a user
+    #    user:
+    #       name: "{{ ansible_host }}"
+    #       groups: "wheel"
+    #       append: yes
+    #       comment: "The User we will run docker as"
+    #       state: present
+    #    become: true
+# This was necessary to get docker running on the AWS Linux 2 AMI
+    - name: Install Docker CE CentOS-specific dependencies
+      block:
+      # region https://docs.docker.com/install/linux/docker-ce/centos/#set-up-the-repository
+      - name: Install yum-utils
+        package:
+          name: yum-utils
+          state: present
+      - name: Install device-mapper-persistent-data
+        package:
+          name: device-mapper-persistent-data
+          state: present
+      - name: Install lvm2
+        package:
+          name: lvm2
+          state: present
+      # endregion
+      # region https://github.com/docker/for-linux/issues/299#issuecomment-390976518
+      - name: yum makecache fast
+        shell: yum makecache fast
+      - name: Install container-selinux
+        shell: yum install -y http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.42-1.gitad8f0f7.el7.noarch.rpm
+        become: true
+        ignore_errors: yes
+
+      # endregion
+  
   roles:
-    - { role: geerlingguy.docker, docker_users: ["{{ ansible_user }}"], become: true }
+  # For some reason, the ec2-user is not being added to the docker group. Have to do that by hand
+    - { role: geerlingguy.docker, docker_users: ["{{ ansible_host }}"], become: true}
     - { role: geerlingguy.git, become: true }
     - { role: geerlingguy.pip, become: true }
 #    - unfetter  
+
+
  

--- a/ansible/task-prep-remote-host.yml
+++ b/ansible/task-prep-remote-host.yml
@@ -1,6 +1,7 @@
 ---
 ####################################################################################
-#  This playbook only builds the docker images locally
+# This Playbook will attempt to deploy EC2 instances, configured properly for testing
+#    and operation 
 #
 ####################################################################################
 
@@ -15,10 +16,13 @@
 
  # - debug:
  #     var: result
-
+  pre_tasks:
+    - include_role:
+         name: unfetter
+         tasks_from: generate-ssh-keys.yml
   roles:
     - { role: geerlingguy.docker, docker_users: ["{{ ansible_user }}"], become: true }
     - { role: geerlingguy.git, become: true }
     - { role: geerlingguy.pip, become: true }
-    - unfetter  
+#    - unfetter  
  

--- a/ansible/task-prep-remote-host.yml
+++ b/ansible/task-prep-remote-host.yml
@@ -1,24 +1,29 @@
 ---
 ####################################################################################
-#  This playbook only builds the docker images locally
+# This Playbook will attempt to deploy EC2 instances, configured properly for testing
+#    and operation 
 #
 ####################################################################################
 
 
 - name: Prepare the Docker Host 
-  hosts: deployed 
+  hosts: prod-legacy-uac 
 #  become: true
   vars:
+     ansible_python_interpreter: python
      pip_install_packages:
        - name: docker
   tasks:
 
  # - debug:
  #     var: result
-
+  pre_tasks:
+    - include_role:
+         name: unfetter
+         tasks_from: generate-ssh-keys.yml
   roles:
     - { role: geerlingguy.docker, docker_users: ["{{ ansible_user }}"], become: true }
     - { role: geerlingguy.git, become: true }
     - { role: geerlingguy.pip, become: true }
-    - unfetter  
+#    - unfetter  
  

--- a/ansible/task-start-ec2-hosts.yml
+++ b/ansible/task-start-ec2-hosts.yml
@@ -1,7 +1,15 @@
 ---
 ####################################################################################
-# This Playbook will attempt to deploy EC2 instances, configured properly for testing
-#    and operation 
+#  This playbook will attempt to start EC2 instances that have the tag:
+#    deployment-group: unfetter
+#    and has a tag "deployment-group" with a value of the host name.
+#
+#  This will allow multiple tests to be run at the same time.
+#
+#
+#   
+#  The original plan for this playbook was to build the EC2 instances.
+# 
 #
 ####################################################################################
 

--- a/ansible/task-start-ec2-hosts.yml
+++ b/ansible/task-start-ec2-hosts.yml
@@ -12,9 +12,8 @@
     build: false # If send in a "true", then will actually build any of the hosts
     # This is used to distinquish between deployment groups.  Each user could have their own test 
     #   Environment
-    deployment_group: "{{ deployment_owner | default('unfetter')"
-    deploy_tag_name: "unfetter-deploy"
-    owner_tag_name: "deployment-group"
+    deploy_name: "unfetter"
+    region: "us-east-1" # Make this by gathering aws_facts
   connection: local
    
   tasks:
@@ -25,7 +24,7 @@
     ec2_instance_facts:
         filters:
             "tag:unfetter-deploy": "{{ groups['deployed'] }}"
-
+            "tag:deployment-group": "{{ deploy_name }}"
             "instance-state-name": 
                  - "starting"
                  - "running"
@@ -37,7 +36,8 @@
   - name: "showing groups['deployed']"
     debug:
       msg: "{{ groups['deployed'] }}"
-
+  - debug:
+      msg: "{{ ec2_facts }}"
   - set_fact: 
      deployed_names: []
   - name: "building deployed_names"
@@ -46,9 +46,12 @@
   - debug:
        msg: "{{ item }}"
     with_items: "{{ deployed_names }}"
-
   - set_fact:
-      found_ec2: "{{ ec2_facts.instances|map(attribute='tags.{{ deploy_tag_name }}')|list }}"
+      found_ec2: "{{ ec2_facts.instances|map(attribute='tags.unfetter-deploy')|list }}"
+
+  - debug:
+      msg: "{{ found_ec2 }}"
+
   - name: "Display found"
     debug:
       var: found_ec2
@@ -56,6 +59,7 @@
 
   - set_fact:
        no_ec2_list: []
+
   - set_fact: 
        no_ec2_list: "{{ no_ec2_list|default([]) | union([item]) }}"
     with_items: "{{ deployed_names }}"
@@ -63,10 +67,12 @@
 
   - name: Failed if EC2's were not found
     fail:
+       msg: "ERROR: The Following EC2 Instances have not been deployed: {{ no_ec2_list }}"
+    when: no_ec2_list|length > 0 and build
+
+  - debug:
        msg: "WARNING: The Following EC2 Instances have not been deployed: {{ no_ec2_list }}"
-    when: no_ec2_list|length > 0 
-
-
+    when: no_ec2_list|length > 0
   - name: "Start Stopped Instances"
     ec2:
        region: '{{ region }}'

--- a/ansible/task-start-ec2-hosts.yml
+++ b/ansible/task-start-ec2-hosts.yml
@@ -1,0 +1,81 @@
+---
+####################################################################################
+# This Playbook will attempt to deploy EC2 instances, configured properly for testing
+#    and operation 
+#
+####################################################################################
+
+
+- hosts: 127.0.0.1
+  vars:
+    
+    build: false # If send in a "true", then will actually build any of the hosts
+    # This is used to distinquish between deployment groups.  Each user could have their own test 
+    #   Environment
+    deployment_group: "{{ deployment_owner | default('unfetter')"
+    deploy_tag_name: "unfetter-deploy"
+    owner_tag_name: "deployment-group"
+  connection: local
+   
+  tasks:
+  - debug:
+      msg: "{{ groups['deployed'] }}"
+
+  - name: "Determine if EC2 instances are created"
+    ec2_instance_facts:
+        filters:
+            "tag:unfetter-deploy": "{{ groups['deployed'] }}"
+
+            "instance-state-name": 
+                 - "starting"
+                 - "running"
+                 - "pending"
+                 - "stopping"
+                 - "stopped"
+
+    register: ec2_facts
+  - name: "showing groups['deployed']"
+    debug:
+      msg: "{{ groups['deployed'] }}"
+
+  - set_fact: 
+     deployed_names: []
+  - name: "building deployed_names"
+    set_fact: 
+      deployed_names: "{{ groups['deployed'] }}"
+  - debug:
+       msg: "{{ item }}"
+    with_items: "{{ deployed_names }}"
+
+  - set_fact:
+      found_ec2: "{{ ec2_facts.instances|map(attribute='tags.{{ deploy_tag_name }}')|list }}"
+  - name: "Display found"
+    debug:
+      var: found_ec2
+
+
+  - set_fact:
+       no_ec2_list: []
+  - set_fact: 
+       no_ec2_list: "{{ no_ec2_list|default([]) | union([item]) }}"
+    with_items: "{{ deployed_names }}"
+    when: item not in found_ec2 
+
+  - name: Failed if EC2's were not found
+    fail:
+       msg: "WARNING: The Following EC2 Instances have not been deployed: {{ no_ec2_list }}"
+    when: no_ec2_list|length > 0 
+
+
+  - name: "Start Stopped Instances"
+    ec2:
+       region: '{{ region }}'
+       instance_tags:
+          unfetter-deploy: "{{ item }}"
+       state: running
+    with_items: "{{ groups['deployed'] }}"
+
+- hosts: deployed
+  vars:
+  tasks:
+     - debug: msg="play_hosts={{ play_hosts }}"


### PR DESCRIPTION
Can now configure and deploy unfetter to a remote host.
- No code to be checked out at remote host
- Fully deploy docker to centos hosts
- Support remote backups

Code to start EC2 instances that have the proper tags

Tested with host_vars file for deployment specific infrastructure

To test:
Build EC2 instances based on Centos machines.
- Create tag called "deployment-group" with a value of "unfetter"
- Create a tag called "unfetter-deployed" with the ansible hostname
Ensure SSH user access from orchestration box to host
Install Python to remote host to support Ansible
Build host_var files for every desired deployed configuration
Change the [deployed] group in hosts.ini


`ansible-playbook task-prep-remote-host.yml`
`ansible-playbook deploy.yml`

This will build Unfetter on that remote host.