### PR TITLE
Demo to change local docker image for deployment specific purpose

### DIFF
--- a/ansible/post-deploy.yml
+++ b/ansible/post-deploy.yml
@@ -1,6 +1,8 @@
 ---
 ####################################################################################
-#  This playbook only builds the docker images locally
+#  This playbook is a test to see how to specifically change a file or files in a container, 
+#     then rebuild the image itself for continued deployment.  This is designed for 
+#     deployment specific purposes
 #
 ####################################################################################
 

--- a/ansible/post-deploy.yml
+++ b/ansible/post-deploy.yml
@@ -14,9 +14,9 @@
   - name: Move something to the container
     shell: "{{ item }}"
     with_items:
-      - "docker cp /tmp/api/file1.js unfetter-discover-api:/usr/share/unfetter-discover-api/node_modules/oauth/lib/file1.js"
+      - "docker cp /tmp/api/file1.js unfetter-discover-api:/tmp/file1.js"
       
   - name: Commit change
     shell: "docker commit unfetter-discover-api unfetter-discover-api:{{ docker_tag }}"
 
-
+  

--- a/ansible/post-deploy.yml
+++ b/ansible/post-deploy.yml
@@ -1,0 +1,20 @@
+---
+####################################################################################
+#  This playbook only builds the docker images locally
+#
+####################################################################################
+
+# This is an example of a file that can be used to over write files in deployment
+- name: Test file change and rebuild of docker image
+  hosts: deployed
+  tasks:
+
+  - name: Move something to the container
+    shell: "{{ item }}"
+    with_items:
+      - "docker cp /tmp/api/file1.js unfetter-discover-api:/usr/share/unfetter-discover-api/node_modules/oauth/lib/file1.js"
+      
+  - name: Commit change
+    shell: "docker commit unfetter-discover-api unfetter-discover-api:{{ docker_tag }}"
+
+


### PR DESCRIPTION
This playbook is a demonstration for how to deploy a change to a docker image after initial build.

- Build docker
- On the remote system, make sure a file "/tmp/api/file1js" exists

```
ansible-playbook post-deploy.yml
docker exec -it unfetter-discover-api ls /tmp
```

The file should exist.
```
docker stop $(docker ps -a -q)
docker rm $(docker ps -a -q)
ansible-playbook deploy.yml
docker exec -it unfetter-discover-api ls /tmp
```
The file should still exist