### PR TITLE
Adds ec2-user to docker group

### DIFF
--- a/ansible/hosts.ini
+++ b/ansible/hosts.ini
@@ -3,6 +3,7 @@
 
 [deployed]
 prod-uac
+
 #  these should NEVER be used in production
 [development]
 dev-demo

--- a/ansible/task-prep-remote-host.yml
+++ b/ansible/task-prep-remote-host.yml
@@ -54,16 +54,7 @@
   
   roles:
   # For some reason, the ec2-user is not being added to the docker group. Have to do that by hand
-    - { role: geerlingguy.docker, docker_users: ["{{ ansible_host }}"], become: true}
+    - { role: geerlingguy.docker, docker_users: ["{{ ansible_user }}"], become: true}
     - { role: geerlingguy.git, become: true }
     - { role: geerlingguy.pip, become: true }
     - unfetter  
-
-  tasks:
-    - name: Add user to docker group
-      user:
-        name: '{{ ansible_user }}'
-        groups: docker
-        append: yes
-      become: true
-

--- a/ansible/task-prep-remote-host.yml
+++ b/ansible/task-prep-remote-host.yml
@@ -10,7 +10,7 @@
 
 - name: Prepare the Docker Host 
 #  become: true
-  hosts: dev-demo
+  hosts: deployed
   vars:
      ansible_python_interpreter: python
      pip_install_packages:

--- a/ansible/task-prep-remote-host.yml
+++ b/ansible/task-prep-remote-host.yml
@@ -10,7 +10,7 @@
 
 - name: Prepare the Docker Host 
 #  become: true
-  hosts: deployed
+  hosts: dev-demo
   vars:
      ansible_python_interpreter: python
      pip_install_packages:
@@ -57,5 +57,13 @@
     - { role: geerlingguy.docker, docker_users: ["{{ ansible_host }}"], become: true}
     - { role: geerlingguy.git, become: true }
     - { role: geerlingguy.pip, become: true }
-#    - unfetter  
+    - unfetter  
+
+  tasks:
+    - name: Add user to docker group
+      user:
+        name: '{{ ansible_user }}'
+        groups: docker
+        append: yes
+      become: true
 


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1480.

- Create an EC2 instance.
  - Amazon Linux 2
  - Since you won't actually be deploying a running Unfetter instance, a `t2.micro` instance will be more than enough.
  - skip past configuration and storage
  - Add 2 tags (this is from PR https://github.com/unfetter-discover/unfetter/pull/1471):
    - `deployment-group` = `unfetter`
    - `unfetter-deployed` = `dev-demo`
  - security group (I recommend `launch-wizard-2`)
  - launch (be sure to use your cert)

- Edit `ansible/task-prep-remote-host.yml`. Set `hosts:` variable near top of file to value `dev-demo`.

- `vi ansible/host_vars/dev-demo.yml`
  - `:read ansible/host_vars/demo-file.yml`
  - set remote_tmp to `/tmp`
  - set ansible_user to `ec2-user`
  - set ansible_ssh_private_key_file to the full path of your PEM certificate from AWS
  - set ansible_host to the IP address of your EC2 instance
  - set api_domain and ui_domain to the _domain_ of your EC2 instance
  - exit vi

- Run the playbook (`ansible-playbook ansible/task-prep-remote-host.yml`).
  - Should complete normally (ignore purple text).

- Log in to the EC2 instance (`ssh -i <path-to-your-PEM-file> ec2-user@<ec2-domain>`)
  - Try a docker command (`docker images`). Should not get an error.
  - Check for git clones (`ls -la /tmp/unfetter/code/`). Should see four repos.

- Clean up
  - Terminate the EC2 instance.
  - Reset the remote prep playbook to HEAD (`git checkout -- ansible/task-prep-remote-host.yml`).