### PR TITLE
removed invalid property

### DIFF
--- a/ansible/roles/gateway/tasks/main.yml
+++ b/ansible/roles/gateway/tasks/main.yml
@@ -53,7 +53,6 @@
     src: '{{ role_path }}/templates/default.j2'
     dest: '{{ backup_directory }}/gateway/conf.d/default.conf'
     force: true
-  remote_src: true 
 
 - name:  "Copy Conf.d.extra to backup"
   copy:


### PR DESCRIPTION
Removes an invalid property.  For earlier versions of Ansible, it would give a warning.  But in later versions (at least 2.7.0), it throws an error.

Running ansible-playbook deploy.yml should result in no errors or warnings for remote_src invalid property