### PR TITLE
Centralized proxy variable in Ansible

### DIFF
--- a/ansible/discover-tasks.yml
+++ b/ansible/discover-tasks.yml
@@ -54,6 +54,7 @@
           - "ansible_ssh_private_key_file = {{ ansible_ssh_private_key_file }}"
           - "ansible_connection = {{ ansible_connection }}"
           - "run_mode = {{ run_mode }}"
+          - "https_proxy_url = {{ https_proxy_url }}"
 
 
 

--- a/ansible/discover-tasks.yml
+++ b/ansible/discover-tasks.yml
@@ -35,6 +35,7 @@
      ansible_connection: "{{ overrides.ansible_connection | default(ansible_connection) }}"
      ansible_python_interpreter: "{{ overrides.ansible_python_interpreter | default(ansible_python_interpreter) }}"
      gateway_tag: "{{ overrides.gateway_tag | default(gateway_tag) }}"
+     https_proxy_url: "{{ overrides.https_proxy_url | default(https_proxy_url) }}"
   
                     
   #  Displaying the variables.

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -23,6 +23,8 @@ gateway_tag: "{{ docker_tag }}.uac"
 
 legacy: false
 
-
-#  Turn to "true" if you would like to block attachments
+# Turn to "true" if you would like to block attachments
 block_attachments: false 
+
+# Override in group_vars/override_vars.yml to use a proxy
+https_proxy_url: ""

--- a/ansible/group_vars/override_vars.yml
+++ b/ansible/group_vars/override_vars.yml
@@ -12,4 +12,4 @@
     #ansible_host: "127.0.0.1"
     #ansible_ssh_private_key_file: "~/.ssh/ansible"
     #ansible_connection: "ssh"
-    #https_proxy_url: ""
+    https_proxy_url: ""

--- a/ansible/group_vars/override_vars.yml
+++ b/ansible/group_vars/override_vars.yml
@@ -12,4 +12,3 @@
     #ansible_host: "127.0.0.1"
     #ansible_ssh_private_key_file: "~/.ssh/ansible"
     #ansible_connection: "ssh"
-    https_proxy_url: ""

--- a/ansible/group_vars/override_vars.yml
+++ b/ansible/group_vars/override_vars.yml
@@ -12,5 +12,5 @@
     #ansible_host: "127.0.0.1"
     #ansible_ssh_private_key_file: "~/.ssh/ansible"
     #ansible_connection: "ssh"
-    
+    #https_proxy_url: "<url>"
     

--- a/ansible/group_vars/override_vars.yml
+++ b/ansible/group_vars/override_vars.yml
@@ -12,5 +12,4 @@
     #ansible_host: "127.0.0.1"
     #ansible_ssh_private_key_file: "~/.ssh/ansible"
     #ansible_connection: "ssh"
-    #https_proxy_url: "<url>"
-    
+    #https_proxy_url: ""

--- a/ansible/host_vars/demo-file.yml
+++ b/ansible/host_vars/demo-file.yml
@@ -7,4 +7,4 @@ ansible_ssh_private_key_file: "xxxxxxx"
 ansible_host: "xx.xx.xxx.xxx"
 api_domain: "{{ ansible_host }}"
 ui_domain: "{{ ansible_host }}"
-
+https_proxy_url: "http://host:port"

--- a/ansible/roles/api/tasks/main.yml
+++ b/ansible/roles/api/tasks/main.yml
@@ -41,7 +41,7 @@
     # Options: UAC, TEST, DEMO
       RUN_MODE: "{{ 'UAC' if use_uac else 'DEMO' }}"
     # If deployed in a proxy, add the proxy's URL here
-      HTTPS_PROXY_URL: ""
+      HTTPS_PROXY_URL: "{{ https_proxy_url }}"
       PATTERN_HANDLER_DOMAIN: unfetter-pattern-handler
       PATTERN_HANDLER_PORT: 5000
       SOCKET_SERVER_DOMAIN: "{{ 'unfetter-socket-server' if use_uac else '' }}"

--- a/ansible/roles/processor/tasks/main.yml
+++ b/ansible/roles/processor/tasks/main.yml
@@ -32,7 +32,7 @@
      PATTERN_HANDLER_PORT: 5000    
      MONGO_HOST: cti-stix-store-repository
      # If deployed in a proxy, add the proxy's URL here
-     HTTPS_PROXY_URL: ''
+     HTTPS_PROXY_URL: "{{ https_proxy_url }}"
     entrypoint:
     
      - ts-node

--- a/ansible/roles/socket-server/tasks/main.yml
+++ b/ansible/roles/socket-server/tasks/main.yml
@@ -35,7 +35,7 @@
       MONGO_PORT: 27017
       MONGO_DBNAME: stix
       # If deployed in a proxy, add the proxy's URL here
-      HTTPS_PROXY_URL: ''
+      HTTPS_PROXY_URL: "{{ https_proxy_url }}"
       # Options: true, false ; NOTE Always commit set to `false`
       SEND_EMAIL_ALERTS: false
       # This is only needed if using SEND_EMAIL_ALERTS *AND* private-config.email.json does not have a service email address


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1457

The HTTPS_PROXY_URL variable has been moved out if the processor, api, and socket server roles and into a centralized Ansible file (all.yml) and can be overridden at the hosts level. Default proxy setting is empty as before.

### To test:
1. Pull this branch
2. Introduce an override file (e.g. dev.yml for deploying in development mode) in the host_vars directory under unfetter/ansible
3. Add https_proxy_url: <some url> to dev.yml
4. Start the stack
5. Confirm that the proxy URL above is shown in the debug task variable listing