### PR TITLE
Fixes unfetter-threat-ingest working directory

### DIFF
--- a/ansible/roles/threat-ingest/tasks/main.yml
+++ b/ansible/roles/threat-ingest/tasks/main.yml
@@ -34,7 +34,7 @@
       MONGO_DB: stix
       SOCKET_SERVER_HOST: unfetter-socket-server
       SOCKET_SERVER_PORT: 3333
-    working_dir: /usr/src/unfetter-threat-ingest
+    working_dir: /usr/share/unfetter-threat-ingest
     entrypoint:
       - npm
       - run


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1554.

Simply makes working directory consistent across other unfetter products.

Use with https://github.com/unfetter-discover/unfetter-store/pull/274.