### PR TITLE
Bugfix 1577/threat ingest demo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,7 +112,7 @@ services:
       - run
       - start
       - --
-      - --debug
+#      - --debug
 #      - --cert-dir=/etc/pki/tls/certs
 #      - --server-key=server.key
 #      - --server-cert=server.crt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,7 +111,8 @@ services:
       - npm
       - run
       - start
-#      - --debug
+      - --
+      - --debug
 #      - --cert-dir=/etc/pki/tls/certs
 #      - --server-key=server.key
 #      - --server-cert=server.crt


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1577.

- Start the docker-compose.yml file in unfetter (`docker-compose up -d`)

- In another terminal, watch the threat ingest logs (`docker logs -f unfetter-threat-ingest`)

- You may want to clear out some reports, open UI, maybe create a new threatboard with a target or two that will match a common label in the DoD News feed (such as `news` or `military operations`).

- In the threat ingest logs, when a new report is saved, it should not attempt to fire a notification.