### PR TITLE
readme: Clarify supported OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Docker-compose is part of the installation
 * [Docker Compose](https://www.docker.com/products/docker-compose) is installed with Community Edition
 * Install [Git](https://git-scm.com/download/mac) and necessary tools
 
-## No Longer Supported
 ### Windows:
+#### No Longer Supported
 We no longer support deployment on Windows systems.  It is still possible with alterations, but we are focusing more on automated deployment through Ansible and scripts.  And Windows Docker just works differently
 
 ### Linux/Ubuntu:


### PR DESCRIPTION
Using a second-level header for "No Longer Supported" hierarchically placed Linux/Ubuntu in the No Longer Supported category. This change moves it to a fourth-level header that is a child of the third-level Windows header.